### PR TITLE
Animate reviews and FAQ cards

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -195,6 +195,9 @@ main{display:block;overflow-x:hidden}
   border-radius:16px;
   color:var(--muted);
   box-shadow:var(--shadow);
+  opacity:0;
+  transform:translateY(12px);
+  transition:transform .8s cubic-bezier(.2,.9,.2,1), opacity .8s;
 }
 
 /* FAQ accordion */
@@ -205,7 +208,9 @@ main{display:block;overflow-x:hidden}
   padding:14px 18px;
   background:rgba(255,255,255,.05);
   box-shadow:var(--shadow);
-  transition:background .3s;
+  opacity:0;
+  transform:translateY(12px);
+  transition:transform .8s cubic-bezier(.2,.9,.2,1), opacity .8s, background .3s;
 }
 #faq details summary{
   font-weight:600;
@@ -213,7 +218,14 @@ main{display:block;overflow-x:hidden}
   outline:none;
 }
 #faq details[open]{background:rgba(255,255,255,.08);}
+#faq details.reveal{transition:transform .8s cubic-bezier(.2,.9,.2,1), opacity .8s, background .3s;}
 #faq p{margin-top:8px;}
+
+.business-list li{
+  opacity:0;
+  transform:translateY(12px);
+  transition:transform .8s cubic-bezier(.2,.9,.2,1), opacity .8s;
+}
 
 /* Donation dialog */
 dialog#donateDialog{

--- a/js/app.js
+++ b/js/app.js
@@ -81,7 +81,7 @@
       }
     });
   }, { threshold: 0.15 });
-  document.querySelectorAll('.step, .review, details').forEach((el) => observer.observe(el));
+  document.querySelectorAll('.step, .review, details, .business-list li').forEach((el) => observer.observe(el));
 })();
 
  


### PR DESCRIPTION
## Summary
- add reveal animation baselines to reviews, FAQ entries, and business list items so they animate consistently with steps
- extend the intersection observer to watch business list items for reveal animations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de383c86a4832fa33436dda74fa813