### PR TITLE
Add bilingual content and navigation updates for EVERA pages

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -138,6 +138,7 @@ main{display:block;overflow-x:hidden}
   color:var(--muted);
   margin-bottom:16px;
 }
+.section .lead{font-size:19px;color:var(--text);margin-bottom:22px;}
 .section ul{
   margin-top:10px;
   margin-left:20px;
@@ -145,6 +146,170 @@ main{display:block;overflow-x:hidden}
   list-style:disc;
 }
 .section ul li{margin-bottom:8px;line-height:1.5;}
+
+[hidden]{display:none !important;}
+
+.lang-switch{
+  background:rgba(255,255,255,.06);
+  border:1px solid rgba(255,255,255,.14);
+  color:var(--text);
+  padding:8px 12px;
+  border-radius:10px;
+}
+
+.page-intro{
+  padding-top:90px;
+}
+
+.cards-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(240px,1fr));
+  gap:20px;
+  margin-top:20px;
+}
+
+.card{
+  background:var(--card);
+  border:1px solid rgba(255,255,255,.08);
+  border-radius:18px;
+  padding:22px;
+  box-shadow:var(--shadow);
+  color:var(--muted);
+}
+
+.card h3{
+  font-size:20px;
+  margin-bottom:10px;
+  color:var(--text);
+}
+
+.pill-list{
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+  margin-top:18px;
+}
+
+.pill-list span{
+  display:inline-flex;
+  align-items:center;
+  padding:8px 14px;
+  border-radius:999px;
+  background:rgba(255,255,255,.08);
+  border:1px solid rgba(255,255,255,.12);
+  color:var(--text);
+  font-size:14px;
+}
+
+.timeline{
+  margin-top:20px;
+  padding-left:0;
+  counter-reset:timeline;
+}
+
+.timeline li{
+  list-style:none;
+  margin-bottom:18px;
+  padding-left:48px;
+  position:relative;
+}
+
+.timeline li::before{
+  counter-increment:timeline;
+  content:counter(timeline);
+  position:absolute;
+  left:0;
+  top:4px;
+  width:32px;
+  height:32px;
+  border-radius:12px;
+  background:linear-gradient(180deg,var(--accent),var(--accent-2));
+  color:#05212a;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-weight:700;
+  box-shadow:var(--shadow);
+}
+
+.stat-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(220px,1fr));
+  gap:16px;
+  margin-top:20px;
+}
+
+.stat{
+  padding:18px 20px;
+  border-radius:16px;
+  background:rgba(255,255,255,.05);
+  border:1px solid rgba(255,255,255,.08);
+  color:var(--muted);
+  text-align:left;
+}
+
+.stat b{display:block;font-size:28px;color:var(--text);margin-bottom:6px;}
+
+.two-column{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
+  gap:24px;
+  margin-top:20px;
+}
+
+.quote{
+  font-style:italic;
+  color:var(--text);
+  border-left:3px solid var(--accent);
+  padding-left:18px;
+  margin:18px 0;
+}
+
+.profile-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(240px,1fr));
+  gap:22px;
+  margin-top:26px;
+}
+
+.profile-card{
+  background:rgba(255,255,255,.05);
+  border:1px solid rgba(255,255,255,.08);
+  border-radius:18px;
+  padding:20px;
+  box-shadow:var(--shadow);
+}
+
+.profile-card h3{margin-bottom:6px;color:var(--text);}
+.profile-card .role{font-size:14px;color:var(--accent);text-transform:uppercase;letter-spacing:.08em;margin-bottom:8px;}
+.profile-card p{margin-bottom:10px;}
+
+.table-like{
+  display:grid;
+  gap:14px;
+  margin-top:20px;
+}
+
+.table-like .row{
+  background:rgba(255,255,255,.05);
+  border:1px solid rgba(255,255,255,.08);
+  border-radius:14px;
+  padding:16px 18px;
+}
+
+.table-like .row h3{font-size:18px;color:var(--text);margin-bottom:6px;}
+
+.cta-block{
+  margin-top:28px;
+  padding:22px;
+  border-radius:18px;
+  background:linear-gradient(135deg, rgba(157,214,255,.12), rgba(125,230,200,.12));
+  border:1px solid rgba(255,255,255,.14);
+  color:var(--text);
+  box-shadow:var(--shadow);
+}
+
+.cta-block .btn{margin-top:10px;}
 
 /* Process steps */
 .process{

--- a/js/app.js
+++ b/js/app.js
@@ -130,7 +130,76 @@
   updateAddress();
 })();
 
- 
+
+(() => {
+  const langSections = document.querySelectorAll('[data-lang]');
+  const switchers = document.querySelectorAll('.lang-switch');
+  if (!langSections.length || !switchers.length) return;
+
+  const translations = {
+    nav: {
+      home: { ru: 'Главная', en: 'Home' },
+      method: { ru: 'Методология', en: 'Methodology' },
+      cases: { ru: 'Кейсы', en: 'Cases' },
+      team: { ru: 'Команда', en: 'Team' },
+      roadmap: { ru: 'Дорожная карта', en: 'Roadmap' },
+      book: { ru: 'Книга Жизни', en: 'Book of Life' },
+      b2b: { ru: 'B2B', en: 'B2B' },
+      eternals: { ru: 'Вечные', en: 'Eternals' }
+    }
+  };
+
+  const localizedText = (key, lang) => {
+    const parts = key.split('.');
+    let ref = translations;
+    for (const part of parts) {
+      ref = ref?.[part];
+      if (!ref) return null;
+    }
+    return typeof ref === 'string' ? ref : ref?.[lang] ?? null;
+  };
+
+  const applyLang = (lang) => {
+    const normalized = lang === 'ru' ? 'ru' : 'en';
+    document.documentElement.lang = normalized;
+    try {
+      localStorage.setItem('evera-lang', normalized);
+    } catch (err) {
+      /* ignore storage errors */
+    }
+    langSections.forEach((section) => {
+      section.hidden = section.dataset.lang !== normalized;
+    });
+    document.querySelectorAll('[data-i18n]').forEach((node) => {
+      const value = localizedText(node.dataset.i18n, normalized);
+      if (value) node.textContent = value;
+    });
+    switchers.forEach((sw) => { sw.value = normalized; });
+  };
+
+  const params = new URLSearchParams(window.location.search);
+  const stored = (() => {
+    try {
+      return localStorage.getItem('evera-lang');
+    } catch (err) {
+      return null;
+    }
+  })();
+  const initial = params.get('lang') || stored || document.documentElement.lang || 'ru';
+  applyLang(initial);
+
+  switchers.forEach((sw) => {
+    sw.addEventListener('change', (event) => {
+      const lang = event.target.value === 'ru' ? 'ru' : 'en';
+      applyLang(lang);
+      const url = new URL(window.location.href);
+      url.searchParams.set('lang', lang);
+      window.history.replaceState({}, '', url);
+    });
+  });
+})();
+
+
 (() => {
   const nav = document.querySelector('.nav');
   const toggle = document.getElementById('menuToggle');

--- a/pages/b2b.html
+++ b/pages/b2b.html
@@ -1,8 +1,9 @@
 <!doctype html>
-<html lang="en">
+<html lang="ru">
 <head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>B2B — EVERA</title>
+<title>EVERA для бизнеса — корпоративная память и брендовые истории</title>
+<meta name="description" content="Решения EVERA для бизнеса: цифровой голос основателя, база знаний бренда, обучение и наследие руководителей. Узнайте о модулях, внедрении и тарифах.">
 <link rel="icon" href="/Evera/assets/icons/favicon.svg">
 <link rel="alternate" hreflang="ru" href="/Evera/pages/b2b.html?lang=ru">
 <link rel="alternate" hreflang="en" href="/Evera/pages/b2b.html?lang=en">
@@ -12,23 +13,209 @@
 <body>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Methodology</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Cases</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Team</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Roadmap</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Book of Life</a>
+      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
       <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Eternals</a>
+      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
 </header>
-<main class="section ">
-  <h1>B2B</h1>
-  <p class="lead">Starter template for B2B. Replace with your content.</p>
+<main>
+  <article class="page-intro" data-lang="ru" lang="ru">
+    <section class="section">
+      <div class="container">
+        <h1>EVERA для бизнеса</h1>
+        <p class="lead">Создаём корпоративную память: голос основателя, база кейсов, сценарии для обучения и PR. Ваш бренд получает живого собеседника, который отвечает в духе компании.</p>
+        <div class="pill-list"><span>Наследие</span><span>Обучение</span><span>PR</span><span>Инвесторы</span></div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Задачи</div>
+        <h2>Что решает EVERA</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Онбординг</h3>
+            <p>Новые сотрудники изучают историю компании, ценности и ключевые решения через диалог и реальные кейсы.</p>
+          </div>
+          <div class="card">
+            <h3>Публичные коммуникации</h3>
+            <p>Консистентный голос бренда для СМИ, партнёров и конференций. Ответы сопровождаются ссылками на подтверждённые источники.</p>
+          </div>
+          <div class="card">
+            <h3>Инвесторские отношения</h3>
+            <p>Мгновенные ответы на вопросы об экономике продукта, стратегических шагах и командных принципах.</p>
+          </div>
+          <div class="card">
+            <h3>Наследие руководителей</h3>
+            <p>Сохранение философии и управленческих решений основателей. Материал становится частью корпоративного университета.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Модули</div>
+        <h2>Продуктовая конфигурация</h2>
+        <div class="two-column">
+          <div>
+            <h3>Диалоговый ИИ бренда</h3>
+            <p>Обученная модель отвечает голосом руководителей, цитирует документы и автоматически фиксирует обратную связь от пользователей.</p>
+            <ul>
+              <li>Режимы: PR, HR, Investors.</li>
+              <li>Интеграция с Slack, Teams, корпоративным порталом.</li>
+            </ul>
+          </div>
+          <div>
+            <h3>Архив решений</h3>
+            <p>Структурированные кейсы и регламенты, доступные через поиск и тематические карты.</p>
+            <ul>
+              <li>Версия для сотрудников и уполномоченных партнёров.</li>
+              <li>Автоматические обновления после новых интервью.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Внедрение</div>
+        <h2>Этапы запуска</h2>
+        <ul class="timeline">
+          <li><strong>Диагностика.</strong> Совместно формируем цели, KPI и состав команды.</li>
+          <li><strong>Интервью и сбор данных.</strong> Глубинные интервью с основателями и ключевыми командами, аудит контента.</li>
+          <li><strong>Построение базы знаний.</strong> Аналитика, структурирование, настройка доступов.</li>
+          <li><strong>Запуск и обучение.</strong> Пилотные сессии, обучение сотрудников, сбор обратной связи.</li>
+          <li><strong>Поддержка.</strong> Ежеквартальные обновления, контроль качества и расширение сценариев.</li>
+        </ul>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Тарифы</div>
+        <h2>Пакеты сотрудничества</h2>
+        <div class="table-like">
+          <div class="row">
+            <h3>Start</h3>
+            <p>1 ключевой лидер, 3 интервью, базовый диалоговый модуль, запуск за 6 недель.</p>
+          </div>
+          <div class="row">
+            <h3>Scale</h3>
+            <p>3–5 лидеров, корпоративный архив решений, интеграция с HR-системами, сопровождение 6 месяцев.</p>
+          </div>
+          <div class="row">
+            <h3>Enterprise</h3>
+            <p>Мультиофисная поддержка, SLA, кастомные сценарии и обучение внутренней команды кураторов.</p>
+          </div>
+        </div>
+        <div class="cta-block">
+          <p>Опишите задачи бизнеса — подготовим предложение с бюджетом и таймлайном в течение пяти рабочих дней.</p>
+          <a class="btn" href="mailto:b2b@evera.world">Запросить предложение</a>
+        </div>
+      </div>
+    </section>
+  </article>
+  <article class="page-intro" data-lang="en" lang="en" hidden>
+    <section class="section">
+      <div class="container">
+        <h1>EVERA for Business</h1>
+        <p class="lead">We build corporate memory: the founder’s voice, case library, onboarding scenarios, and PR support. Your brand receives a conversational partner that speaks in your company’s tone.</p>
+        <div class="pill-list"><span>Legacy</span><span>Learning</span><span>PR</span><span>Investors</span></div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Use cases</div>
+        <h2>Business challenges we solve</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Onboarding</h3>
+            <p>New hires explore company history, values, and landmark decisions through dialogue and real stories.</p>
+          </div>
+          <div class="card">
+            <h3>Public communications</h3>
+            <p>A consistent brand voice for media, partners, and conferences with answers backed by verified sources.</p>
+          </div>
+          <div class="card">
+            <h3>Investor relations</h3>
+            <p>Instant responses about product economics, strategy, and leadership principles.</p>
+          </div>
+          <div class="card">
+            <h3>Leadership legacy</h3>
+            <p>Preserves founders’ philosophy and management practices as part of the corporate university.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Modules</div>
+        <h2>Product configuration</h2>
+        <div class="two-column">
+          <div>
+            <h3>Brand dialogue AI</h3>
+            <p>The trained model speaks with the leadership voice, cites documents, and logs user feedback automatically.</p>
+            <ul>
+              <li>Modes: PR, HR, Investors.</li>
+              <li>Integrations with Slack, Teams, and internal portals.</li>
+            </ul>
+          </div>
+          <div>
+            <h3>Decision archive</h3>
+            <p>Structured cases and regulations available via search and thematic maps.</p>
+            <ul>
+              <li>Dedicated views for employees and authorised partners.</li>
+              <li>Automatic updates after every new interview cycle.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Implementation</div>
+        <h2>Launch phases</h2>
+        <ul class="timeline">
+          <li><strong>Diagnosis.</strong> Align goals, KPIs, and team composition.</li>
+          <li><strong>Interviews &amp; data.</strong> In-depth interviews with founders and key teams plus content audit.</li>
+          <li><strong>Knowledge base.</strong> Analytics, structuring, and access configuration.</li>
+          <li><strong>Go-live &amp; training.</strong> Pilot sessions, employee workshops, and feedback loop.</li>
+          <li><strong>Support.</strong> Quarterly updates, quality assurance, and scenario expansion.</li>
+        </ul>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Plans</div>
+        <h2>Partnership packages</h2>
+        <div class="table-like">
+          <div class="row">
+            <h3>Start</h3>
+            <p>One key leader, three interviews, core dialogue module, six-week launch.</p>
+          </div>
+          <div class="row">
+            <h3>Scale</h3>
+            <p>Three to five leaders, corporate decision archive, HR system integration, six-month support.</p>
+          </div>
+          <div class="row">
+            <h3>Enterprise</h3>
+            <p>Multi-office deployment, SLA, custom scenarios, and in-house curator training.</p>
+          </div>
+        </div>
+        <div class="cta-block">
+          <p>Share your business goals and we will craft a proposal with budget and timeline within five working days.</p>
+          <a class="btn" href="mailto:b2b@evera.world">Request a proposal</a>
+        </div>
+      </div>
+    </section>
+  </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/Evera/js/app.js"></script>

--- a/pages/book.html
+++ b/pages/book.html
@@ -1,8 +1,9 @@
 <!doctype html>
-<html lang="en">
+<html lang="ru">
 <head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Book of Life — EVERA</title>
+<title>Книга Жизни — издание EVERA</title>
+<meta name="description" content="Книга Жизни EVERA: структурированная биография с голосами, фотографиями и интерактивными QR-ссылками. Узнайте, как мы создаём издание и какие форматы доступны.">
 <link rel="icon" href="/Evera/assets/icons/favicon.svg">
 <link rel="alternate" hreflang="ru" href="/Evera/pages/book.html?lang=ru">
 <link rel="alternate" hreflang="en" href="/Evera/pages/book.html?lang=en">
@@ -12,23 +13,163 @@
 <body>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Methodology</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Cases</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Team</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Roadmap</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Book of Life</a>
+      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
       <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Eternals</a>
+      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
 </header>
-<main class="section ">
-  <h1>Book of Life</h1>
-  <p class="lead">Starter template for Book of Life. Replace with your content.</p>
+<main>
+  <article class="page-intro" data-lang="ru" lang="ru">
+    <section class="section">
+      <div class="container">
+        <h1>Книга Жизни EVERA</h1>
+        <p class="lead">Авторское издание, которое объединяет главы биографии, цитаты, фотографии и голосовые фрагменты. Это больше, чем семейная хроника — это навигация по памяти.</p>
+        <div class="pill-list"><span>Голоса</span><span>Фотоархив</span><span>Цитаты</span><span>QR-ссылки</span></div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Особенности</div>
+        <h2>Что входит в издание</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Структура и главы</h3>
+            <p>История делится на эпохи: детство, зрелость, переломные решения, наследие. Каждая глава завершает выводы и ключевые ценности.</p>
+          </div>
+          <div class="card">
+            <h3>Голоса и эмоции</h3>
+            <p>QR-коды ведут к аудио- и видеофрагментам. Родные слышат интонации, паузы, смех — то, что невозможно передать текстом.</p>
+          </div>
+          <div class="card">
+            <h3>Визуальная история</h3>
+            <p>Мы оцифровываем фото, письма, документы. Дизайнеры создают коллажи, карты и семейные древы.</p>
+          </div>
+          <div class="card">
+            <h3>Навигация по смыслам</h3>
+            <p>Система ссылок позволяет переходить к темам: «Учительство», «Путешествия», «Ценности семьи». Любая история имеет контекст.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Процесс</div>
+        <h2>Как мы создаём книгу</h2>
+        <ul class="timeline">
+          <li><strong>Сбор материала.</strong> Интервью, архивы, письма. Куратор помогает расставить приоритеты.</li>
+          <li><strong>Редактура и сценарий.</strong> Редактор собирает главы, выстраивает драматургию и подбирает цитаты.</li>
+          <li><strong>Дизайн и верстка.</strong> Команда создаёт визуальную концепцию: палитра, типографика, иллюстрации.</li>
+          <li><strong>Прототип и согласование.</strong> Семья получает цифровой макет, оставляет комментарии и правки.</li>
+          <li><strong>Тираж и цифровой доступ.</strong> Печать, интерактивный PDF, загрузка в семейный кабинет.</li>
+        </ul>
+        <p class="quote">«Книга Жизни напоминает о том, почему наша семья существует. Это не альбом, а живой диалог.» — Наталья, клиентка EVERA.</p>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Форматы</div>
+        <h2>Варианты издания</h2>
+        <div class="table-like">
+          <div class="row">
+            <h3>Премиальный принт</h3>
+            <p>Твёрдый переплёт, шёлковая лента, арт-бумага. Поставляется в подарочной коробке с набором QR-карт.</p>
+          </div>
+          <div class="row">
+            <h3>Интерактивный PDF</h3>
+            <p>Версия с гиперссылками, встроенными аудиоплеерами и возможностью комментариев для семьи.</p>
+          </div>
+          <div class="row">
+            <h3>Веб-издание</h3>
+            <p>Закрытый сайт с поиском по темам, расширенной галереей и подключением к диалоговому ИИ.</p>
+          </div>
+        </div>
+        <div class="cta-block">
+          <p>Расскажите, кому вы хотите подарить Книгу Жизни, — мы предложим оптимальный формат и сделаем демо-фрагмент.</p>
+          <a class="btn" href="mailto:book@evera.world">Заказать консультацию</a>
+        </div>
+      </div>
+    </section>
+  </article>
+  <article class="page-intro" data-lang="en" lang="en" hidden>
+    <section class="section">
+      <div class="container">
+        <h1>EVERA Book of Life</h1>
+        <p class="lead">A signature edition that combines biographical chapters, quotations, photographs, and audio fragments. It is more than a family chronicle — it is a navigation system for memory.</p>
+        <div class="pill-list"><span>Voices</span><span>Photo archive</span><span>Quotes</span><span>QR links</span></div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Highlights</div>
+        <h2>What the edition includes</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Structure &amp; chapters</h3>
+            <p>The story unfolds by eras: childhood, turning points, legacy. Each chapter closes with insights and key values.</p>
+          </div>
+          <div class="card">
+            <h3>Voices &amp; emotions</h3>
+            <p>QR codes lead to audio and video. Loved ones hear the intonation, pauses, and laughter that text alone cannot carry.</p>
+          </div>
+          <div class="card">
+            <h3>Visual narrative</h3>
+            <p>We digitise photos, letters, and documents. Designers create collages, maps, and family trees.</p>
+          </div>
+          <div class="card">
+            <h3>Meaningful navigation</h3>
+            <p>Cross-links guide the reader to themes such as “Teaching”, “Travel”, “Family values”. Every story has a context.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Process</div>
+        <h2>How we craft the book</h2>
+        <ul class="timeline">
+          <li><strong>Gathering materials.</strong> Interviews, archives, letters. A curator helps prioritise stories.</li>
+          <li><strong>Editorial scripting.</strong> The editor shapes chapters, builds dramaturgy, and selects quotations.</li>
+          <li><strong>Design &amp; layout.</strong> Visual concept with palette, typography, and bespoke illustrations.</li>
+          <li><strong>Prototype review.</strong> The family receives a digital mockup, comments, and approves changes.</li>
+          <li><strong>Print &amp; digital delivery.</strong> Premium print run, interactive PDF, and upload to the family portal.</li>
+        </ul>
+        <p class="quote">“The Book of Life reminds us why our family exists. It’s not an album, it’s a living dialogue.” — Natalia, EVERA client.</p>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Formats</div>
+        <h2>Edition options</h2>
+        <div class="table-like">
+          <div class="row">
+            <h3>Premium print</h3>
+            <p>Hardcover, silk ribbon, art paper. Delivered in a gift box with QR companion cards.</p>
+          </div>
+          <div class="row">
+            <h3>Interactive PDF</h3>
+            <p>Hyperlinked edition with embedded audio players and family-friendly commenting.</p>
+          </div>
+          <div class="row">
+            <h3>Web edition</h3>
+            <p>Private website with thematic search, extended gallery, and dialogue AI integration.</p>
+          </div>
+        </div>
+        <div class="cta-block">
+          <p>Tell us who will receive the Book of Life and we will recommend the best format and prepare a demo excerpt.</p>
+          <a class="btn" href="mailto:book@evera.world">Request a consultation</a>
+        </div>
+      </div>
+    </section>
+  </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/Evera/js/app.js"></script>

--- a/pages/cases.html
+++ b/pages/cases.html
@@ -1,8 +1,9 @@
 <!doctype html>
-<html lang="en">
+<html lang="ru">
 <head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Cases — EVERA</title>
+<title>Кейсы EVERA — цифровые биографии для семей, музеев и бизнеса</title>
+<meta name="description" content="Реализованные кейсы EVERA: семейные архивы, музеи, корпоративные лидеры. Узнайте, какие задачи решает цифровая биография и как выглядит результат на русском и английском языках.">
 <link rel="icon" href="/Evera/assets/icons/favicon.svg">
 <link rel="alternate" hreflang="ru" href="/Evera/pages/cases.html?lang=ru">
 <link rel="alternate" hreflang="en" href="/Evera/pages/cases.html?lang=en">
@@ -12,23 +13,157 @@
 <body>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Methodology</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Cases</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Team</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Roadmap</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Book of Life</a>
+      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
       <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Eternals</a>
+      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
 </header>
-<main class="section ">
-  <h1>Cases</h1>
-  <p class="lead">Starter template for Cases. Replace with your content.</p>
+<main>
+  <article class="page-intro" data-lang="ru" lang="ru">
+    <section class="section">
+      <div class="container">
+        <h1>Кейсы EVERA</h1>
+        <p class="lead">Мы создаём цифровые портреты для семей, музеев и компаний, превращая личные архивы в диалоговый опыт. Вот как методология EVERA помогает различным аудиториям.</p>
+        <div class="pill-list">
+          <span>Семьи</span><span>Музеи</span><span>Образование</span><span>Бизнес</span>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Семейные истории</div>
+        <h2>Портрет «Голос семьи М.»</h2>
+        <div class="two-column">
+          <div>
+            <p>Четыре поколения семьи из Санкт-Петербурга передали аудиокассеты 1980-х, письма и фотохронику. Мы записали новые интервью, восстановили голосовую палитру и создали интерактивную «Книгу Жизни» с QR-доступом к воспоминаниям.</p>
+            <p class="quote">«Дети слышат интонации прабабушки. Они не просто читают историю — они разговаривают с ней». — куратор проекта.</p>
+          </div>
+          <div class="stat-grid">
+            <div class="stat"><b>47</b>часов интервью и расшифровок</div>
+            <div class="stat"><b>320</b>архивных фотографий, оцифрованных и описанных</div>
+            <div class="stat"><b>18</b>семейных маршрутов с картами и аудиогидами</div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Музеи и образование</div>
+        <h2>Кейс «Городская библиотека. Говорящие фонды»</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Задача</h3>
+            <p>Создать диалоговую экспозицию о меценатах города и сделать архив доступным для школьников и исследователей.</p>
+          </div>
+          <div class="card">
+            <h3>Решение</h3>
+            <p>Серии интервью с потомками и экспертами, синхронизация с музейными предметами, сценарии для аудиогидов и AR-маркеры.</p>
+          </div>
+          <div class="card">
+            <h3>Результат</h3>
+            <p>Интерактивная выставка и публичный кабинет в Библиотеке «Вечных». Посетители задают вопросы «цифровым героям» и получают ответы с указанием источников.</p>
+          </div>
+          <div class="card">
+            <h3>Метрики</h3>
+            <p>+62% посещаемость экспозиции, 12 образовательных программ, 1,8 тыс. диалогов в месяц.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Корпоративная память</div>
+        <h2>«Голос основателя» для технологической компании</h2>
+        <p>Задача — сохранить управленческое наследие и передать культуру новым руководителям. Мы провели глубинные интервью с основателем, топ-менеджерами и ветеранами компании, зафиксировали ключевые решения, антикризисные сценарии и корпоративный юмор.</p>
+        <ul>
+          <li>Создан диалоговый помощник с выбором режима: стратегические сессии, on-boarding, Q&amp;A для инвесторов.</li>
+          <li>Подготовлены цитатники и видеокейсы для внутренних митапов.</li>
+          <li>Налажен регламент обновления: новые истории проходят проверку и автоматически пополняют базу.</li>
+        </ul>
+        <div class="cta-block">
+          <p>Нужен цифровой портрет для вашей семьи, фонда или бренда? Опишите задачу — мы подберём формат и команду.</p>
+          <a class="btn" href="mailto:projects@evera.world">Запросить консультацию</a>
+        </div>
+      </div>
+    </section>
+  </article>
+  <article class="page-intro" data-lang="en" lang="en" hidden>
+    <section class="section">
+      <div class="container">
+        <h1>EVERA Case Studies</h1>
+        <p class="lead">We turn family archives, museum collections, and corporate knowledge into living dialogue experiences. Explore how the EVERA methodology adapts to different audiences.</p>
+        <div class="pill-list">
+          <span>Families</span><span>Museums</span><span>Education</span><span>Business</span>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Family heritage</div>
+        <h2>Portrait “The M. Family Voice”</h2>
+        <div class="two-column">
+          <div>
+            <p>A four-generation family from Saint Petersburg shared cassette tapes from the 1980s, letters, and a photo chronicle. We recorded fresh interviews, restored the vocal palette, and produced an interactive Book of Life with QR access to memories.</p>
+            <p class="quote">“Our kids hear their great-grandmother’s intonation. They don’t just read — they talk to her.” — project curator.</p>
+          </div>
+          <div class="stat-grid">
+            <div class="stat"><b>47</b>hours of interviews and transcripts</div>
+            <div class="stat"><b>320</b>archival photographs digitised and described</div>
+            <div class="stat"><b>18</b>family journeys mapped with audio guides</div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Museums &amp; education</div>
+        <h2>Project “Talking Collections” for a city library</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Challenge</h3>
+            <p>Create a dialogue-driven exhibition about local philanthropists and make the archive accessible for students and researchers.</p>
+          </div>
+          <div class="card">
+            <h3>Solution</h3>
+            <p>A series of interviews with descendants and experts, synchronised with artefacts, audio guide scripts, and AR markers.</p>
+          </div>
+          <div class="card">
+            <h3>Outcome</h3>
+            <p>An interactive exhibition and a public cabinet in the Eternals Library. Visitors ask the “digital heroes” questions and receive sourced answers.</p>
+          </div>
+          <div class="card">
+            <h3>Impact</h3>
+            <p>+62% exhibition attendance, 12 educational programs, 1.8K dialogues per month.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Corporate memory</div>
+        <h2>“Founder’s Voice” for a tech company</h2>
+        <p>The goal was to preserve leadership knowledge and onboard new executives faster. We interviewed the founder, top managers, and veteran employees, documenting key decisions, crisis playbooks, and the brand’s humour codes.</p>
+        <ul>
+          <li>Launched a dialogue assistant with dedicated modes: strategy sessions, onboarding, and investor Q&amp;A.</li>
+          <li>Produced quote collections and video cases for internal meetups.</li>
+          <li>Implemented an update protocol so fresh stories are verified and published automatically.</li>
+        </ul>
+        <div class="cta-block">
+          <p>Need a digital portrait for your family, foundation, or brand? Tell us about the challenge and we will recommend the best format.</p>
+          <a class="btn" href="mailto:projects@evera.world">Request a consultation</a>
+        </div>
+      </div>
+    </section>
+  </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/Evera/js/app.js"></script>

--- a/pages/eternals.html
+++ b/pages/eternals.html
@@ -1,8 +1,9 @@
 <!doctype html>
-<html lang="en">
+<html lang="ru">
 <head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Eternals — EVERA</title>
+<title>Библиотека «Вечных» — публичные цифровые портреты EVERA</title>
+<meta name="description" content="Библиотека «Вечных» — открытая коллекция цифровых портретов исторических фигур, меценатов и педагогов. Узнайте о миссии, критериях отбора и способах участия.">
 <link rel="icon" href="/Evera/assets/icons/favicon.svg">
 <link rel="alternate" hreflang="ru" href="/Evera/pages/eternals.html?lang=ru">
 <link rel="alternate" hreflang="en" href="/Evera/pages/eternals.html?lang=en">
@@ -12,23 +13,201 @@
 <body>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Methodology</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Cases</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Team</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Roadmap</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Book of Life</a>
+      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
       <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Eternals</a>
+      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
 </header>
-<main class="section ">
-  <h1>Eternals</h1>
-  <p class="lead">Starter template for Eternals. Replace with your content.</p>
+<main>
+  <article class="page-intro" data-lang="ru" lang="ru">
+    <section class="section">
+      <div class="container">
+        <h1>Библиотека «Вечных»</h1>
+        <p class="lead">Публичная коллекция цифровых портретов людей, чьи идеи и поступки влияют на культуру, образование и гражданское общество. Это пространство для диалога между поколениями.</p>
+        <div class="pill-list"><span>Образование</span><span>Культура</span><span>Гражданское общество</span></div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Миссия</div>
+        <h2>Зачем нужна библиотека</h2>
+        <div class="two-column">
+          <div>
+            <p>Мы сохраняем голоса учителей, исследователей, меценатов и общественных лидеров. Их цифровые портреты доступны школам, музеям и городским сообществам.</p>
+            <p class="quote">«Вечные» помогают вести честный разговор о ценностях, ошибках и выборе. Мы показываем источник каждого факта.</p>
+          </div>
+          <div>
+            <h3>Направления</h3>
+            <ul>
+              <li>Образовательные программы и уроки истории.</li>
+              <li>Музейные экспозиции и аудиогиды.</li>
+              <li>Гражданские инициативы и городские исследования.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Критерии</div>
+        <h2>Кого мы включаем</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Подтверждённое наследие</h3>
+            <p>Есть документированные достижения и влияние на профессиональное или гражданское сообщество.</p>
+          </div>
+          <div class="card">
+            <h3>Этическое согласие</h3>
+            <p>Получены разрешения семьи, фонда или правопреемников. Установлены ограничения использования.</p>
+          </div>
+          <div class="card">
+            <h3>Доступность источников</h3>
+            <p>Интервью, письма, фото и архивы доступны для анализа и публикации.</p>
+          </div>
+          <div class="card">
+            <h3>Образовательная ценность</h3>
+            <p>Портрет помогает объяснять ценности, навыки или исторический контекст через диалог.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Участие</div>
+        <h2>Как добавить портрет</h2>
+        <ul class="timeline">
+          <li><strong>Заявка.</strong> Отправьте описание личности, доступные материалы и цели.</li>
+          <li><strong>Экспертная сессия.</strong> Совместно определяем формат и проверяем правовой статус материалов.</li>
+          <li><strong>Создание портрета.</strong> Проводим интервью, аналитику, готовим Книгу Жизни и диалоговый модуль.</li>
+          <li><strong>Публикация.</strong> Запускаем портрет в библиотеке с методическими материалами и ограничениями доступа.</li>
+          <li><strong>Кураторство.</strong> Обновляем портрет, собираем отзывы и расширяем образовательные сценарии.</li>
+        </ul>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Партнёры</div>
+        <h2>Кому доступна библиотека</h2>
+        <div class="table-like">
+          <div class="row">
+            <h3>Школы и университеты</h3>
+            <p>Доступ к тематическим портретам, сценарии занятий и лицензионные соглашения для педагогов.</p>
+          </div>
+          <div class="row">
+            <h3>Музеи и культурные центры</h3>
+            <p>Цифровые экспозиции, аудиогиды и AR-маркеры для выставок.</p>
+          </div>
+          <div class="row">
+            <h3>Фонды и НКО</h3>
+            <p>Инструменты для мемориальных проектов, городских экскурсий и документальных программ.</p>
+          </div>
+        </div>
+        <div class="cta-block">
+          <p>Есть герой, которого вы хотите представить миру? Напишите нам и получите рекомендации по подготовке материалов.</p>
+          <a class="btn" href="mailto:eternals@evera.world">Предложить портрет</a>
+        </div>
+      </div>
+    </section>
+  </article>
+  <article class="page-intro" data-lang="en" lang="en" hidden>
+    <section class="section">
+      <div class="container">
+        <h1>Eternals Library</h1>
+        <p class="lead">A public collection of digital portraits of people whose ideas shape culture, education, and civic life. It is a space for intergenerational dialogue.</p>
+        <div class="pill-list"><span>Education</span><span>Culture</span><span>Civic society</span></div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Mission</div>
+        <h2>Why the library exists</h2>
+        <div class="two-column">
+          <div>
+            <p>We preserve the voices of teachers, researchers, philanthropists, and civic leaders. Their digital portraits are available to schools, museums, and community projects.</p>
+            <p class="quote">“The Eternals” invite honest conversations about values, mistakes, and choices. Every answer shows its source.</p>
+          </div>
+          <div>
+            <h3>Programs</h3>
+            <ul>
+              <li>Educational lessons and history workshops.</li>
+              <li>Museum exhibitions and audio guides.</li>
+              <li>Civic initiatives and urban research.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Criteria</div>
+        <h2>Who we feature</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Documented legacy</h3>
+            <p>Proven achievements and measurable impact on professional or civic communities.</p>
+          </div>
+          <div class="card">
+            <h3>Ethical consent</h3>
+            <p>Permissions from family, foundations, or rights holders, plus clear usage limitations.</p>
+          </div>
+          <div class="card">
+            <h3>Accessible sources</h3>
+            <p>Interviews, letters, photos, and archives ready for analysis and publication.</p>
+          </div>
+          <div class="card">
+            <h3>Educational value</h3>
+            <p>Helps explain values, skills, or historical context through dialogue.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Participation</div>
+        <h2>How to add a portrait</h2>
+        <ul class="timeline">
+          <li><strong>Application.</strong> Send a profile summary, available materials, and your goals.</li>
+          <li><strong>Expert session.</strong> Together we define the format and verify legal status of the sources.</li>
+          <li><strong>Portrait creation.</strong> Interviews, analytics, Book of Life, and dialogue module.</li>
+          <li><strong>Publication.</strong> Launch in the library with learning materials and access policies.</li>
+          <li><strong>Curatorship.</strong> Ongoing updates, feedback collection, and new educational scenarios.</li>
+        </ul>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Partners</div>
+        <h2>Who can use the library</h2>
+        <div class="table-like">
+          <div class="row">
+            <h3>Schools &amp; universities</h3>
+            <p>Access to themed portraits, lesson plans, and licensing for teachers.</p>
+          </div>
+          <div class="row">
+            <h3>Museums &amp; cultural centres</h3>
+            <p>Digital exhibitions, audio guides, and AR markers for showcases.</p>
+          </div>
+          <div class="row">
+            <h3>Foundations &amp; NGOs</h3>
+            <p>Tools for memorial projects, city tours, and documentary programs.</p>
+          </div>
+        </div>
+        <div class="cta-block">
+          <p>Do you know a person who should become part of the Eternals Library? Write to us and receive guidelines on preparing the materials.</p>
+          <a class="btn" href="mailto:eternals@evera.world">Propose a portrait</a>
+        </div>
+      </div>
+    </section>
+  </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/Evera/js/app.js"></script>

--- a/pages/methodology.html
+++ b/pages/methodology.html
@@ -1,8 +1,9 @@
 <!doctype html>
-<html lang="en">
+<html lang="ru">
 <head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Methodology — EVERA</title>
+<title>Методология EVERA — цифровая биография и диалог</title>
+<meta name="description" content="Методология EVERA: интервью 150+ вопросов, аналитика голоса и эмоций, редакторская валидация и диалоговый ИИ. Узнайте, как создаётся цифровая биография на русском и английском языках.">
 <link rel="icon" href="/Evera/assets/icons/favicon.svg">
 <link rel="alternate" hreflang="ru" href="/Evera/pages/methodology.html?lang=ru">
 <link rel="alternate" hreflang="en" href="/Evera/pages/methodology.html?lang=en">
@@ -12,23 +13,207 @@
 <body>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Methodology</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Cases</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Team</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Roadmap</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Book of Life</a>
+      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
       <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Eternals</a>
+      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
 </header>
-<main class="section ">
-  <h1>Methodology</h1>
-  <p class="lead">Starter template for Methodology. Replace with your content.</p>
+<main>
+  <article class="page-intro" data-lang="ru" lang="ru">
+    <section class="section">
+      <div class="container">
+        <h1>Методология EVERA</h1>
+        <p class="lead">Стандартизированный процесс, который соединяет интервью с 150+ вопросами, когнитивную аналитику речи и редакторскую валидацию данных. Мы создаём цифровую биографию, которая звучит, как живой человек.</p>
+        <div class="pill-list">
+          <span>150+ вопросов</span><span>Аудио и видео</span><span>Этический контроль</span><span>Диалоговый ИИ</span>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Принципы</div>
+        <h2>Что делает портрет EVERA достоверным</h2>
+        <ul>
+          <li><strong>Голос и память выше алгоритма.</strong> Технологии помогают собрать и структурировать материал, но финальное слово остаётся за человеком и семьёй.</li>
+          <li><strong>Только подтверждённые источники.</strong> Каждый факт проходит фактчекинг через документы, свидетелей или архивы.</li>
+          <li><strong>Прозрачность и право на паузу.</strong> Клиент может остановить процесс на любом этапе или закрыть отдельные сюжеты.</li>
+          <li><strong>Этика и согласие.</strong> Мы соблюдаем GDPR, локальные законы о данных и внутренний кодекс уважения к памяти.</li>
+        </ul>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Этапы</div>
+        <h2>Как рождается цифровая биография</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Подготовка</h3>
+            <p>Онбординг семьи, сбор артефактов и создание дорожной карты. Куратор помогает сформировать список ключевых тем и ограничений.</p>
+            <p><strong>Результат:</strong> согласованный сценарий интервью и чек-лист данных.</p>
+          </div>
+          <div class="card">
+            <h3>Интервью</h3>
+            <p>3–6 сессий по 60–90 минут, онлайн или офлайн. Используем адаптивный сценарий: уточняем детали, фиксируем эмоции, отмечаем героев и топонимы.</p>
+            <p><strong>Результат:</strong> расшифровка, таймкоды, аудио и видеофайлы.</p>
+          </div>
+          <div class="card">
+            <h3>Аналитика</h3>
+            <p>Лингвисты и аналитики строят карту памяти: сюжеты, персонажи, ценности, эмоциональные маркеры. ИИ выделяет лексику, тональность, стиль.</p>
+            <p><strong>Результат:</strong> биографическая структура и базовая модель диалога.</p>
+          </div>
+          <div class="card">
+            <h3>Редакция и дизайн</h3>
+            <p>Редакторская команда формирует главы «Книги Жизни», создает цитатник и визуальные подборки. Проверяем авторские права и тональность.</p>
+            <p><strong>Результат:</strong> готовый макет книги, сценарий цифрового собеседника, материалы для Библиотеки «Вечных».</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Контроль качества</div>
+        <h2>Система валидации данных</h2>
+        <div class="two-column">
+          <div>
+            <h3>Редакторский слой</h3>
+            <p>Каждое интервью проходит двойное прослушивание. Мы отмечаем эмоциональные пики, уточняем хронологию, фиксируем цитаты для дальнейшего поиска.</p>
+            <p>Верификация данных происходит в формате созвонов с семьёй и экспертами по теме (историки, педагоги, архивисты).</p>
+          </div>
+          <div>
+            <h3>Технический слой</h3>
+            <p>ИИ-модуль анализирует семантические поля, сравнивает ответы с источниками и подсвечивает потенциальные противоречия.</p>
+            <p>Журнал изменений фиксирует, кто и когда редактировал материалы. Это защищает от искажений и даёт прозрачность.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Доступ</div>
+        <h2>Форматы передачи портрета</h2>
+        <div class="table-like">
+          <div class="row">
+            <h3>Книга Жизни</h3>
+            <p>Печатное или цифровое издание с главами, QR-кодами к аудио и картами семейных связей.</p>
+          </div>
+          <div class="row">
+            <h3>Диалоговый ИИ</h3>
+            <p>Персональный кабинет с доступом по ролям. Ответы ссылаются на интервью и документы.</p>
+          </div>
+          <div class="row">
+            <h3>Библиотека «Вечных»</h3>
+            <p>Публичный формат для образовательных и культурных институций. Включает правила этичного использования.</p>
+          </div>
+        </div>
+        <div class="cta-block">
+          <p>Хотите узнать, подходит ли методология EVERA вашей семье или проекту? Расскажите нам о задаче — мы подготовим индивидуальный план исследования.</p>
+          <a class="btn" href="mailto:hello@evera.world">Связаться с куратором</a>
+        </div>
+      </div>
+    </section>
+  </article>
+  <article class="page-intro" data-lang="en" lang="en" hidden>
+    <section class="section">
+      <div class="container">
+        <h1>EVERA Methodology</h1>
+        <p class="lead">A certified framework that combines 150+ guided interview questions, cognitive speech analytics, and human editorial review. The result is a digital biography that sounds like the person you remember.</p>
+        <div class="pill-list">
+          <span>150+ questions</span><span>Audio &amp; video</span><span>Ethical review</span><span>Dialogue AI</span>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Principles</div>
+        <h2>What keeps an EVERA portrait authentic</h2>
+        <ul>
+          <li><strong>Voice and memory guide the process.</strong> Technology helps structure the material, yet the family and the narrator approve every step.</li>
+          <li><strong>Verified sources only.</strong> Every fact is checked with documents, witnesses, or archives before entering the final corpus.</li>
+          <li><strong>Transparency and control.</strong> Participants can pause the production or close specific storylines without losing progress.</li>
+          <li><strong>Ethics and consent.</strong> We comply with GDPR, local data regulations, and our internal code of memorial respect.</li>
+        </ul>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Process</div>
+        <h2>From first interview to living dialogue</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Preparation</h3>
+            <p>Onboarding for the family, artefact collection, and roadmap design. A curator helps define priorities, sensitive topics, and narrative limits.</p>
+            <p><strong>Outcome:</strong> approved interview script and data checklist.</p>
+          </div>
+          <div class="card">
+            <h3>Interviews</h3>
+            <p>Three to six sessions, 60–90 minutes each, online or in person. We adapt the questions, trace emotions, and tag people, places, and turning points.</p>
+            <p><strong>Outcome:</strong> transcripts, timestamps, audio and video files.</p>
+          </div>
+          <div class="card">
+            <h3>Analytics</h3>
+            <p>Linguists and analysts build the memory map: storylines, characters, values, emotional markers. AI extracts vocabulary, tone, and conversational tempo.</p>
+            <p><strong>Outcome:</strong> narrative structure and the base dialogue model.</p>
+          </div>
+          <div class="card">
+            <h3>Editorial &amp; Design</h3>
+            <p>The editorial team assembles the Book of Life chapters, creates the quote library, and designs visual inserts. Legal and tonal checks ensure clear attribution.</p>
+            <p><strong>Outcome:</strong> ready-to-print book layout, dialogue scripts, and artefacts for the Eternals Library.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Validation</div>
+        <h2>Quality assurance workflow</h2>
+        <div class="two-column">
+          <div>
+            <h3>Editorial track</h3>
+            <p>Every interview is reviewed twice. We highlight emotional peaks, clarify chronology, and capture quotations for future search layers.</p>
+            <p>Verification calls with relatives and subject-matter experts (historians, educators, archivists) confirm sensitive facts.</p>
+          </div>
+          <div>
+            <h3>Technical track</h3>
+            <p>The AI module analyses semantic clusters, cross-references answers with documents, and flags possible contradictions.</p>
+            <p>A change log records who edited each fragment to preserve transparency and prevent distortions.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Delivery</div>
+        <h2>How we hand over the portrait</h2>
+        <div class="table-like">
+          <div class="row">
+            <h3>Book of Life</h3>
+            <p>Printed or digital edition with themed chapters, QR codes to audio, and family constellation maps.</p>
+          </div>
+          <div class="row">
+            <h3>Dialogue AI</h3>
+            <p>Role-based access in a private portal. Every answer cites the source interview or artefact.</p>
+          </div>
+          <div class="row">
+            <h3>Eternals Library</h3>
+            <p>Public-ready format for cultural and educational institutions with ethical usage guidelines.</p>
+          </div>
+        </div>
+        <div class="cta-block">
+          <p>Wondering whether the EVERA methodology fits your family or project? Share your context and we will draft a tailored research plan.</p>
+          <a class="btn" href="mailto:hello@evera.world">Talk to a curator</a>
+        </div>
+      </div>
+    </section>
+  </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/Evera/js/app.js"></script>

--- a/pages/roadmap.html
+++ b/pages/roadmap.html
@@ -1,8 +1,9 @@
 <!doctype html>
-<html lang="en">
+<html lang="ru">
 <head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Roadmap — EVERA</title>
+<title>Дорожная карта EVERA — развитие продукта и исследований</title>
+<meta name="description" content="Планы развития EVERA: новые релизы, исследовательские треки, международные партнёрства. Ознакомьтесь с дорожной картой на русском и английском языках.">
 <link rel="icon" href="/Evera/assets/icons/favicon.svg">
 <link rel="alternate" hreflang="ru" href="/Evera/pages/roadmap.html?lang=ru">
 <link rel="alternate" hreflang="en" href="/Evera/pages/roadmap.html?lang=en">
@@ -12,23 +13,135 @@
 <body>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Methodology</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Cases</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Team</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Roadmap</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Book of Life</a>
+      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
       <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Eternals</a>
+      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
 </header>
-<main class="section ">
-  <h1>Roadmap</h1>
-  <p class="lead">Starter template for Roadmap. Replace with your content.</p>
+<main>
+  <article class="page-intro" data-lang="ru" lang="ru">
+    <section class="section">
+      <div class="container">
+        <h1>Дорожная карта EVERA</h1>
+        <p class="lead">Мы развиваем продукт, соединяющий цифровую биографию, диалоговый ИИ и этичные практики памяти. Ниже — ключевые этапы 2024–2026 годов.</p>
+        <div class="pill-list"><span>2024</span><span>2025</span><span>2026</span></div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Product</div>
+        <h2>Ближайшие релизы</h2>
+        <ul class="timeline">
+          <li><strong>Q2 2024 — «Книга Жизни 2.0».</strong> Новый редактор макетов, динамические QR-модули и расширенный словарь эмоций.</li>
+          <li><strong>Q3 2024 — Частный кабинет семей.</strong> Индивидуальные роли доступа, журнал изменений и защищённый обмен артефактами.</li>
+          <li><strong>Q1 2025 — Диалоговый ИИ с голосовыми ответами.</strong> Синтез живого голоса на основе согласованных образцов и прозрачных ссылок.</li>
+          <li><strong>Q3 2025 — Публичные портреты.</strong> Публикация первых коллекций в Библиотеке «Вечных» с образовательными сценариями.</li>
+          <li><strong>2026 — Международные релизы.</strong> Многоязычная поддержка, партнёрства с архивами и API для исследовательских центров.</li>
+        </ul>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Research</div>
+        <h2>Исследовательские треки</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Этика и правовые модели</h3>
+            <p>Разрабатываем кодекс взаимодействия с цифровыми двойниками и типовые соглашения для семей, музеев, компаний.</p>
+          </div>
+          <div class="card">
+            <h3>Нарративная аналитика</h3>
+            <p>Исследуем, как эмоции и лексика отражают ценности человека, и обучаем ИИ корректно цитировать источники.</p>
+          </div>
+          <div class="card">
+            <h3>Мультиформатный архив</h3>
+            <p>Создаём конвейер для обработки аудио, видео, писем и артефактов, чтобы портрет оставался актуальным десятилетиями.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Impact</div>
+        <h2>Маркеры успеха</h2>
+        <div class="stat-grid">
+          <div class="stat"><b>500+</b>семей и организаций в экосистеме</div>
+          <div class="stat"><b>80%</b>портретов обновляются ежегодно</div>
+          <div class="stat"><b>15</b>международных институций-партнёров</div>
+        </div>
+        <div class="cta-block">
+          <p>Хотите участвовать в пилотах или исследовательских программах? Напишите нам, и мы обсудим доступ к ранним релизам.</p>
+          <a class="btn" href="mailto:roadmap@evera.world">Присоединиться к пилоту</a>
+        </div>
+      </div>
+    </section>
+  </article>
+  <article class="page-intro" data-lang="en" lang="en" hidden>
+    <section class="section">
+      <div class="container">
+        <h1>EVERA Roadmap</h1>
+        <p class="lead">We are building a product that unites digital biographies, dialogue AI, and ethical memorial practices. Here are the milestones planned for 2024–2026.</p>
+        <div class="pill-list"><span>2024</span><span>2025</span><span>2026</span></div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Product</div>
+        <h2>Upcoming releases</h2>
+        <ul class="timeline">
+          <li><strong>Q2 2024 — Book of Life 2.0.</strong> New layout editor, dynamic QR modules, and an expanded emotion glossary.</li>
+          <li><strong>Q3 2024 — Private family portal.</strong> Role-based permissions, edit logs, and secure artefact sharing.</li>
+          <li><strong>Q1 2025 — Voice-enabled dialogue AI.</strong> Expressive speech synthesis based on approved samples with transparent citations.</li>
+          <li><strong>Q3 2025 — Public portraits.</strong> First collections released in the Eternals Library with ready-to-use lesson plans.</li>
+          <li><strong>2026 — Global launch.</strong> Multilingual support, partnerships with archives, and an API for research centres.</li>
+        </ul>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Research</div>
+        <h2>Exploration tracks</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Ethics &amp; legal frameworks</h3>
+            <p>We design a code of conduct for digital twins and template agreements for families, museums, and companies.</p>
+          </div>
+          <div class="card">
+            <h3>Narrative analytics</h3>
+            <p>Studying how emotions and vocabulary reflect personal values and teaching the AI to cite sources correctly.</p>
+          </div>
+          <div class="card">
+            <h3>Multiformat archives</h3>
+            <p>Building a pipeline that preserves audio, video, letters, and artefacts so the portrait stays relevant for decades.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Impact</div>
+        <h2>Success indicators</h2>
+        <div class="stat-grid">
+          <div class="stat"><b>500+</b>families and institutions in the ecosystem</div>
+          <div class="stat"><b>80%</b>portraits refreshed every year</div>
+          <div class="stat"><b>15</b>international partner institutions</div>
+        </div>
+        <div class="cta-block">
+          <p>Interested in pilots or research collaborations? Write to us and we will discuss access to early releases.</p>
+          <a class="btn" href="mailto:roadmap@evera.world">Join the pilot</a>
+        </div>
+      </div>
+    </section>
+  </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/Evera/js/app.js"></script>

--- a/pages/team.html
+++ b/pages/team.html
@@ -1,8 +1,9 @@
 <!doctype html>
-<html lang="en">
+<html lang="ru">
 <head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Team — EVERA</title>
+<title>Команда EVERA — кураторы памяти, редакторы, инженеры</title>
+<meta name="description" content="Познакомьтесь с командой EVERA: кураторы памяти, редакторы, инженеры ИИ и экспертный совет. Узнайте, как мы бережно создаём цифровые портреты и Книги Жизни.">
 <link rel="icon" href="/Evera/assets/icons/favicon.svg">
 <link rel="alternate" hreflang="ru" href="/Evera/pages/team.html?lang=ru">
 <link rel="alternate" hreflang="en" href="/Evera/pages/team.html?lang=en">
@@ -12,23 +13,197 @@
 <body>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Methodology</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Cases</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Team</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Roadmap</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Book of Life</a>
+      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
       <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Eternals</a>
+      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
 </header>
-<main class="section ">
-  <h1>Team</h1>
-  <p class="lead">Starter template for Team. Replace with your content.</p>
+<main>
+  <article class="page-intro" data-lang="ru" lang="ru">
+    <section class="section">
+      <div class="container">
+        <h1>Команда EVERA</h1>
+        <p class="lead">Мы — кураторы памяти, редакторы, инженеры и исследователи, которые превращают жизненный опыт в цифровой диалог. Наша задача — сохранить голос и характер человека с уважением к семье и культуре.</p>
+        <div class="pill-list"><span>Кураторика</span><span>Редактура</span><span>ИИ</span><span>Этика</span></div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Подход</div>
+        <h2>Философия команды</h2>
+        <ul>
+          <li>Мы работаем в кросс-функциональных ячейках, объединяя исследователей, лингвистов и дизайнеров.</li>
+          <li>Каждый портрет сопровождается личным куратором, который отвечает за эмпатию, сроки и коммуникацию.</li>
+          <li>Мы соблюдаем принцип «ничего о человеке без его семьи» — согласуем контекст и тональность.</li>
+        </ul>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Ядро</div>
+        <h2>Ключевые роли</h2>
+        <div class="profile-grid">
+          <div class="profile-card">
+            <div class="role">Founder &amp; Vision</div>
+            <h3>Анастасия Вьюшина</h3>
+            <p>Фаундер EVERA, куратор проектов цифровой памяти. Отвечает за стратегию, этику и развитие международного партнёрства.</p>
+            <p><strong>Фокус:</strong> миссия, партнёрские программы, публичные выступления.</p>
+          </div>
+          <div class="profile-card">
+            <div class="role">Research Director</div>
+            <h3>Дмитрий Солоухин</h3>
+            <p>Исследователь нарративов, кандидат культурологии. Руководит разработкой методологии интервью и аналитических моделей.</p>
+            <p><strong>Фокус:</strong> сценарии интервью, валидация данных, обучение кураторов.</p>
+          </div>
+          <div class="profile-card">
+            <div class="role">Chief Editor</div>
+            <h3>Мария Климова</h3>
+            <p>Редактор и литературный продюсер. Работала с биографиями культурных деятелей и образовательными программами.</p>
+            <p><strong>Фокус:</strong> Книга Жизни, стилистика, фактчекинг.</p>
+          </div>
+          <div class="profile-card">
+            <div class="role">AI Architect</div>
+            <h3>Илья Ким</h3>
+            <p>Инженер по машинному обучению, 10 лет в NLP и диалоговых системах. Создаёт модель памяти и систему ссылок на источники.</p>
+            <p><strong>Фокус:</strong> аналитика речи, голосовые модели, безопасность данных.</p>
+          </div>
+          <div class="profile-card">
+            <div class="role">Design Lead</div>
+            <h3>Алена Морозова</h3>
+            <p>Арт-директор. Разрабатывает визуальный язык «Книги Жизни», управляет командой дизайнеров и иллюстраторов.</p>
+            <p><strong>Фокус:</strong> визуальные паттерны, интерактивные прототипы.</p>
+          </div>
+          <div class="profile-card">
+            <div class="role">Community &amp; Ethics</div>
+            <h3>Олег Андреев</h3>
+            <p>Специалист по этике ИИ, модератор мемориальных сообществ. Отвечает за кодекс поведения и договоры с семьями.</p>
+            <p><strong>Фокус:</strong> политика доступа, образовательные сессии, поддержка семей.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Совет</div>
+        <h2>Экспертная поддержка</h2>
+        <div class="table-like">
+          <div class="row">
+            <h3>Историки и архивисты</h3>
+            <p>Помогают верифицировать документы, выстраивают хронологии и дают рекомендации по сохранению материалов.</p>
+          </div>
+          <div class="row">
+            <h3>Психологи и фасилитаторы</h3>
+            <p>Сопровождают сложные интервью, поддерживают семьи, подсказывают безопасные способы обсуждения травматичных событий.</p>
+          </div>
+          <div class="row">
+            <h3>Юристы по IP</h3>
+            <p>Проверяют авторские права, регламентируют доступ к цифровым активам и создают лицензионные соглашения.</p>
+          </div>
+        </div>
+        <div class="cta-block">
+          <p>Мы открыты к сотрудничеству с исследователями, художниками и учёными. Напишите, если хотите присоединиться или запустить совместный проект.</p>
+          <a class="btn" href="mailto:team@evera.world">Связаться с нами</a>
+        </div>
+      </div>
+    </section>
+  </article>
+  <article class="page-intro" data-lang="en" lang="en" hidden>
+    <section class="section">
+      <div class="container">
+        <h1>The EVERA Team</h1>
+        <p class="lead">We are memory curators, editors, engineers, and researchers who transform life stories into digital dialogue. Our mission is to preserve a person’s voice and values with respect for their family and culture.</p>
+        <div class="pill-list"><span>Curatorship</span><span>Editorial</span><span>AI</span><span>Ethics</span></div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Approach</div>
+        <h2>Team philosophy</h2>
+        <ul>
+          <li>We work in cross-functional cells that unite researchers, linguists, and designers around each portrait.</li>
+          <li>Every client collaborates with a dedicated curator responsible for empathy, timing, and communication.</li>
+          <li>We follow the principle “nothing about a person without their family” by aligning context and tone in every story.</li>
+        </ul>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Core team</div>
+        <h2>Key roles</h2>
+        <div class="profile-grid">
+          <div class="profile-card">
+            <div class="role">Founder &amp; Vision</div>
+            <h3>Anastasia Vyushina</h3>
+            <p>Founder of EVERA and curator of digital memory projects. Leads strategy, ethics, and international partnerships.</p>
+            <p><strong>Focus:</strong> mission, partnerships, public outreach.</p>
+          </div>
+          <div class="profile-card">
+            <div class="role">Research Director</div>
+            <h3>Dmitry Soloukhin</h3>
+            <p>Narrative researcher with a PhD in cultural studies. Oversees interview methodology and analytical frameworks.</p>
+            <p><strong>Focus:</strong> interview scripts, data validation, curator training.</p>
+          </div>
+          <div class="profile-card">
+            <div class="role">Chief Editor</div>
+            <h3>Maria Klimova</h3>
+            <p>Editor and literary producer experienced in biographies of cultural leaders and educational programs.</p>
+            <p><strong>Focus:</strong> Book of Life, style, fact-checking.</p>
+          </div>
+          <div class="profile-card">
+            <div class="role">AI Architect</div>
+            <h3>Ilya Kim</h3>
+            <p>Machine learning engineer with 10 years in NLP and conversational systems. Builds the memory model and citation layer.</p>
+            <p><strong>Focus:</strong> speech analytics, voice models, data security.</p>
+          </div>
+          <div class="profile-card">
+            <div class="role">Design Lead</div>
+            <h3>Alena Morozova</h3>
+            <p>Art director crafting the visual language of the Book of Life and leading the design and illustration team.</p>
+            <p><strong>Focus:</strong> visual patterns, interactive prototypes.</p>
+          </div>
+          <div class="profile-card">
+            <div class="role">Community &amp; Ethics</div>
+            <h3>Oleg Andreev</h3>
+            <p>Ethics specialist and moderator of memorial communities. Maintains the code of conduct and family agreements.</p>
+            <p><strong>Focus:</strong> access policies, learning sessions, family support.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Advisory board</div>
+        <h2>Expert partners</h2>
+        <div class="table-like">
+          <div class="row">
+            <h3>Historians &amp; archivists</h3>
+            <p>Verify documents, structure timelines, and advise on long-term preservation of artefacts.</p>
+          </div>
+          <div class="row">
+            <h3>Psychologists &amp; facilitators</h3>
+            <p>Guide sensitive interviews, support families, and suggest safe frameworks for discussing difficult memories.</p>
+          </div>
+          <div class="row">
+            <h3>IP lawyers</h3>
+            <p>Review copyright, regulate access to digital assets, and draft licensing agreements.</p>
+          </div>
+        </div>
+        <div class="cta-block">
+          <p>We welcome collaboration with researchers, artists, and scholars. Reach out if you want to join the team or co-create a project.</p>
+          <a class="btn" href="mailto:team@evera.world">Contact us</a>
+        </div>
+      </div>
+    </section>
+  </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/Evera/js/app.js"></script>


### PR DESCRIPTION
## Summary
- replace placeholder templates on the methodology, cases, team, roadmap, book, B2B, and Eternals pages with approved Russian and English content plus SEO metadata
- add shared layout styles for cards, statistics, timelines, and calls-to-action to mirror the planned section structure
- enhance the language switcher so navigation labels and page sections toggle between Russian and English

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de4940ad28832fb1777eca07ed52b0