### PR TITLE
Add language switching support for inner landing pages

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -139,3 +139,178 @@
     nav.classList.toggle('open');
   });
 })();
+
+
+(() => {
+  const STORAGE_KEY = 'evera-lang';
+  const DEFAULT_LANG = 'en';
+
+  const translations = {
+    en: {
+      'nav.home': 'Home',
+      'nav.method': 'Methodology',
+      'nav.cases': 'Cases',
+      'nav.team': 'Team',
+      'nav.roadmap': 'Roadmap',
+      'nav.book': 'Book of Life',
+      'nav.b2b': 'B2B',
+      'nav.eternals': 'Eternals',
+      'meta.methodology': 'Methodology — EVERA',
+      'meta.cases': 'Cases — EVERA',
+      'meta.team': 'Team — EVERA',
+      'meta.roadmap': 'Roadmap — EVERA',
+      'meta.book': 'Book of Life — EVERA',
+      'meta.b2b': 'B2B — EVERA',
+      'meta.eternals': 'Eternals — EVERA',
+      'page.methodology.title': 'Methodology',
+      'page.methodology.lead': 'Starter template for Methodology. Replace with your content.',
+      'page.cases.title': 'Cases',
+      'page.cases.lead': 'Starter template for Cases. Replace with your content.',
+      'page.team.title': 'Team',
+      'page.team.lead': 'Starter template for Team. Replace with your content.',
+      'page.roadmap.title': 'Roadmap',
+      'page.roadmap.lead': 'Starter template for Roadmap. Replace with your content.',
+      'page.book.title': 'Book of Life',
+      'page.book.lead': 'Starter template for Book of Life. Replace with your content.',
+      'page.b2b.title': 'B2B',
+      'page.b2b.lead': 'Starter template for B2B. Replace with your content.',
+      'page.eternals.title': 'Eternals',
+      'page.eternals.lead': 'Starter template for Eternals. Replace with your content.'
+    },
+    ru: {
+      'nav.home': 'Главная',
+      'nav.method': 'Методология',
+      'nav.cases': 'Кейсы',
+      'nav.team': 'Команда',
+      'nav.roadmap': 'Дорожная карта',
+      'nav.book': 'Книга жизни',
+      'nav.b2b': 'Для бизнеса',
+      'nav.eternals': 'Вечные',
+      'meta.methodology': 'Методология — EVERA',
+      'meta.cases': 'Кейсы — EVERA',
+      'meta.team': 'Команда — EVERA',
+      'meta.roadmap': 'Дорожная карта — EVERA',
+      'meta.book': 'Книга жизни — EVERA',
+      'meta.b2b': 'B2B — EVERA',
+      'meta.eternals': 'Вечные — EVERA',
+      'page.methodology.title': 'Методология',
+      'page.methodology.lead': 'Шаблон раздела «Методология». Замените этот текст своим содержанием.',
+      'page.cases.title': 'Кейсы',
+      'page.cases.lead': 'Шаблон раздела «Кейсы». Замените этот текст своим содержанием.',
+      'page.team.title': 'Команда',
+      'page.team.lead': 'Шаблон раздела «Команда». Замените этот текст своим содержанием.',
+      'page.roadmap.title': 'Дорожная карта',
+      'page.roadmap.lead': 'Шаблон раздела «Дорожная карта». Замените этот текст своим содержанием.',
+      'page.book.title': 'Книга жизни',
+      'page.book.lead': 'Шаблон раздела «Книга жизни». Замените этот текст своим содержанием.',
+      'page.b2b.title': 'B2B',
+      'page.b2b.lead': 'Шаблон раздела «B2B». Замените этот текст своим содержанием.',
+      'page.eternals.title': 'Вечные',
+      'page.eternals.lead': 'Шаблон раздела «Вечные». Замените этот текст своим содержанием.'
+    }
+  };
+
+  const supportedLanguages = new Set(Object.keys(translations));
+  const htmlEl = document.documentElement;
+
+  function resolveLanguage(lang) {
+    return supportedLanguages.has(lang) ? lang : DEFAULT_LANG;
+  }
+
+  function setTextContent(el, value) {
+    if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+      el.value = value;
+    } else {
+      el.textContent = value;
+    }
+  }
+
+  function updateLinks(lang) {
+    const canonical = document.querySelector('link[rel="canonical"]');
+    if (canonical) {
+      try {
+        const canonicalUrl = new URL(canonical.getAttribute('href'), window.location.origin);
+        canonicalUrl.searchParams.set('lang', lang);
+        canonical.setAttribute('href', canonicalUrl.href);
+      } catch (err) {
+        const href = canonical.getAttribute('href') || '';
+        const base = href.split('?')[0];
+        canonical.setAttribute('href', `${base}?lang=${lang}`);
+      }
+    }
+
+    document.querySelectorAll('link[rel="alternate"][hreflang]').forEach((link) => {
+      const href = link.getAttribute('href') || '';
+      const base = href.split('?')[0];
+      const hreflang = link.getAttribute('hreflang') || '';
+      if (hreflang) {
+        link.setAttribute('href', `${base}?lang=${hreflang}`);
+      } else {
+        link.setAttribute('href', base);
+      }
+    });
+  }
+
+  function updateUrl(lang) {
+    if (!window.history?.replaceState) return;
+    const url = new URL(window.location.href);
+    url.searchParams.set('lang', lang);
+    window.history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`);
+  }
+
+  function applyLanguage(lang) {
+    const resolved = resolveLanguage(lang);
+    htmlEl.lang = resolved;
+
+    document.querySelectorAll('[data-i18n]').forEach((el) => {
+      const key = el.getAttribute('data-i18n');
+      if (!key) return;
+      const value = translations[resolved]?.[key];
+      if (typeof value === 'string') {
+        setTextContent(el, value);
+      }
+    });
+
+    document.querySelectorAll('.lang-switch').forEach((select) => {
+      if (select instanceof HTMLSelectElement && select.value !== resolved) {
+        select.value = resolved;
+      }
+    });
+
+    updateLinks(resolved);
+    updateUrl(resolved);
+
+    try {
+      window.localStorage.setItem(STORAGE_KEY, resolved);
+    } catch (err) {
+      /* localStorage may be disabled */
+    }
+  }
+
+  function init() {
+    let saved = '';
+    try {
+      saved = window.localStorage.getItem(STORAGE_KEY) || '';
+    } catch (err) {
+      saved = '';
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    const urlLang = params.get('lang') || '';
+    const initial = resolveLanguage(urlLang || saved || htmlEl.lang || DEFAULT_LANG);
+    applyLanguage(initial);
+
+    document.querySelectorAll('.lang-switch').forEach((select) => {
+      if (!(select instanceof HTMLSelectElement)) return;
+      select.addEventListener('change', () => {
+        applyLanguage(select.value);
+      });
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+})();

--- a/pages/b2b.html
+++ b/pages/b2b.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>B2B — EVERA</title>
+<title data-i18n="meta.b2b">B2B — EVERA</title>
 <link rel="icon" href="/Evera/assets/icons/favicon.svg">
 <link rel="alternate" hreflang="ru" href="/Evera/pages/b2b.html?lang=ru">
 <link rel="alternate" hreflang="en" href="/Evera/pages/b2b.html?lang=en">
@@ -14,7 +14,7 @@
   <nav class="nav">
     <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html">Home</a>
+      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
       <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Methodology</a>
       <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Cases</a>
       <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Team</a>
@@ -27,8 +27,8 @@
   </nav>
 </header>
 <main class="section ">
-  <h1>B2B</h1>
-  <p class="lead">Starter template for B2B. Replace with your content.</p>
+  <h1 data-i18n="page.b2b.title">B2B</h1>
+  <p class="lead" data-i18n="page.b2b.lead">Starter template for B2B. Replace with your content.</p>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/Evera/js/app.js"></script>

--- a/pages/book.html
+++ b/pages/book.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Book of Life — EVERA</title>
+<title data-i18n="meta.book">Book of Life — EVERA</title>
 <link rel="icon" href="/Evera/assets/icons/favicon.svg">
 <link rel="alternate" hreflang="ru" href="/Evera/pages/book.html?lang=ru">
 <link rel="alternate" hreflang="en" href="/Evera/pages/book.html?lang=en">
@@ -14,7 +14,7 @@
   <nav class="nav">
     <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html">Home</a>
+      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
       <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Methodology</a>
       <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Cases</a>
       <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Team</a>
@@ -27,8 +27,8 @@
   </nav>
 </header>
 <main class="section ">
-  <h1>Book of Life</h1>
-  <p class="lead">Starter template for Book of Life. Replace with your content.</p>
+  <h1 data-i18n="page.book.title">Book of Life</h1>
+  <p class="lead" data-i18n="page.book.lead">Starter template for Book of Life. Replace with your content.</p>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/Evera/js/app.js"></script>

--- a/pages/cases.html
+++ b/pages/cases.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Cases — EVERA</title>
+<title data-i18n="meta.cases">Cases — EVERA</title>
 <link rel="icon" href="/Evera/assets/icons/favicon.svg">
 <link rel="alternate" hreflang="ru" href="/Evera/pages/cases.html?lang=ru">
 <link rel="alternate" hreflang="en" href="/Evera/pages/cases.html?lang=en">
@@ -14,7 +14,7 @@
   <nav class="nav">
     <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html">Home</a>
+      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
       <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Methodology</a>
       <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Cases</a>
       <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Team</a>
@@ -27,8 +27,8 @@
   </nav>
 </header>
 <main class="section ">
-  <h1>Cases</h1>
-  <p class="lead">Starter template for Cases. Replace with your content.</p>
+  <h1 data-i18n="page.cases.title">Cases</h1>
+  <p class="lead" data-i18n="page.cases.lead">Starter template for Cases. Replace with your content.</p>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/Evera/js/app.js"></script>

--- a/pages/eternals.html
+++ b/pages/eternals.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Eternals — EVERA</title>
+<title data-i18n="meta.eternals">Eternals — EVERA</title>
 <link rel="icon" href="/Evera/assets/icons/favicon.svg">
 <link rel="alternate" hreflang="ru" href="/Evera/pages/eternals.html?lang=ru">
 <link rel="alternate" hreflang="en" href="/Evera/pages/eternals.html?lang=en">
@@ -14,7 +14,7 @@
   <nav class="nav">
     <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html">Home</a>
+      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
       <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Methodology</a>
       <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Cases</a>
       <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Team</a>
@@ -27,8 +27,8 @@
   </nav>
 </header>
 <main class="section ">
-  <h1>Eternals</h1>
-  <p class="lead">Starter template for Eternals. Replace with your content.</p>
+  <h1 data-i18n="page.eternals.title">Eternals</h1>
+  <p class="lead" data-i18n="page.eternals.lead">Starter template for Eternals. Replace with your content.</p>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/Evera/js/app.js"></script>

--- a/pages/methodology.html
+++ b/pages/methodology.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Methodology — EVERA</title>
+<title data-i18n="meta.methodology">Methodology — EVERA</title>
 <link rel="icon" href="/Evera/assets/icons/favicon.svg">
 <link rel="alternate" hreflang="ru" href="/Evera/pages/methodology.html?lang=ru">
 <link rel="alternate" hreflang="en" href="/Evera/pages/methodology.html?lang=en">
@@ -14,7 +14,7 @@
   <nav class="nav">
     <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html">Home</a>
+      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
       <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Methodology</a>
       <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Cases</a>
       <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Team</a>
@@ -27,8 +27,8 @@
   </nav>
 </header>
 <main class="section ">
-  <h1>Methodology</h1>
-  <p class="lead">Starter template for Methodology. Replace with your content.</p>
+  <h1 data-i18n="page.methodology.title">Methodology</h1>
+  <p class="lead" data-i18n="page.methodology.lead">Starter template for Methodology. Replace with your content.</p>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/Evera/js/app.js"></script>

--- a/pages/roadmap.html
+++ b/pages/roadmap.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Roadmap — EVERA</title>
+<title data-i18n="meta.roadmap">Roadmap — EVERA</title>
 <link rel="icon" href="/Evera/assets/icons/favicon.svg">
 <link rel="alternate" hreflang="ru" href="/Evera/pages/roadmap.html?lang=ru">
 <link rel="alternate" hreflang="en" href="/Evera/pages/roadmap.html?lang=en">
@@ -14,7 +14,7 @@
   <nav class="nav">
     <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html">Home</a>
+      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
       <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Methodology</a>
       <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Cases</a>
       <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Team</a>
@@ -27,8 +27,8 @@
   </nav>
 </header>
 <main class="section ">
-  <h1>Roadmap</h1>
-  <p class="lead">Starter template for Roadmap. Replace with your content.</p>
+  <h1 data-i18n="page.roadmap.title">Roadmap</h1>
+  <p class="lead" data-i18n="page.roadmap.lead">Starter template for Roadmap. Replace with your content.</p>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/Evera/js/app.js"></script>

--- a/pages/team.html
+++ b/pages/team.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Team — EVERA</title>
+<title data-i18n="meta.team">Team — EVERA</title>
 <link rel="icon" href="/Evera/assets/icons/favicon.svg">
 <link rel="alternate" hreflang="ru" href="/Evera/pages/team.html?lang=ru">
 <link rel="alternate" hreflang="en" href="/Evera/pages/team.html?lang=en">
@@ -14,7 +14,7 @@
   <nav class="nav">
     <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html">Home</a>
+      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
       <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Methodology</a>
       <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Cases</a>
       <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Team</a>
@@ -27,8 +27,8 @@
   </nav>
 </header>
 <main class="section ">
-  <h1>Team</h1>
-  <p class="lead">Starter template for Team. Replace with your content.</p>
+  <h1 data-i18n="page.team.title">Team</h1>
+  <p class="lead" data-i18n="page.team.lead">Starter template for Team. Replace with your content.</p>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/Evera/js/app.js"></script>


### PR DESCRIPTION
## Summary
- add translation dictionaries and persistence logic to drive language switching
- annotate inner pages with data-i18n keys for navigation, titles, and lead copy

## Testing
- not run (static pages)


------
https://chatgpt.com/codex/tasks/task_e_68de493f9134832fa6013b070331faad