### PR TITLE
Add nebula background renderer with per-page palettes

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -22,6 +22,15 @@ html,body{
   scroll-behavior:smooth;
 }
 
+#nebula{
+  position:fixed;
+  inset:0;
+  z-index:-2;
+  pointer-events:none;
+  mix-blend-mode:screen;
+  opacity:.85;
+}
+
 #stars{
   position:fixed;
   inset:0;
@@ -155,6 +164,10 @@ main{display:block;overflow-x:hidden}
   color:var(--text);
   padding:8px 12px;
   border-radius:10px;
+}
+
+@media (prefers-reduced-motion:reduce){
+  #nebula{opacity:.65;}
 }
 
 .page-intro{

--- a/index.html
+++ b/index.html
@@ -25,7 +25,9 @@
   <!-- Stylesheet for this page -->
   <link rel="stylesheet" href="css/styles.css">
 </head>
-<body>
+<body data-nebula="home">
+  <!-- Туманность с наложением. Располагается под слоем звёзд. -->
+  <canvas id="nebula" aria-hidden="true"></canvas>
   <!-- Звёздное небо на фоне. Canvas размещён под контентом. -->
   <canvas id="stars" aria-hidden="true"></canvas>
 

--- a/js/app.js
+++ b/js/app.js
@@ -1,6 +1,274 @@
 /* Пустой комментарий удалён для компактности */
 
 (() => {
+  const canvas = document.getElementById('nebula');
+  if (!canvas || !document.body) return;
+  const ctx = canvas.getContext('2d', { alpha: true });
+  if (!ctx) return;
+
+  const paletteKey = (document.body.dataset.nebula || 'default').toLowerCase();
+  const paletteMap = {
+    home: ['#1b0f3b', '#193864', '#1e6d97', '#74c7ff'],
+    methodology: ['#120d2f', '#27406c', '#3e7ba1', '#a3e6ff'],
+    book: ['#1f0d38', '#432560', '#8a47a0', '#f1c9ff'],
+    cases: ['#140d29', '#36265c', '#6f4f97', '#f2b6ff'],
+    b2b: ['#0d142c', '#1c3c59', '#1d6a73', '#7ed7cb'],
+    team: ['#150f30', '#2d3c6c', '#5484c6', '#c5dbff'],
+    roadmap: ['#10112d', '#1f3560', '#2a6e9d', '#8fd5ff'],
+    eternals: ['#130b27', '#3c1f55', '#7b4193', '#f5d6ff'],
+    default: ['#160f2d', '#1c355e', '#2b6f92', '#9ad7ff']
+  };
+  const palette = paletteMap[paletteKey] || paletteMap.default;
+
+  const DPR = Math.min(2, window.devicePixelRatio || 1);
+  const sampleCanvas = document.createElement('canvas');
+  const sampleCtx = sampleCanvas.getContext('2d', { willReadFrequently: true });
+  if (!sampleCtx) return;
+
+  const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+  let width = 0;
+  let height = 0;
+  let sampleW = 0;
+  let sampleH = 0;
+  let imageData = null;
+  let animId = null;
+
+  const noise = createSimplexNoise(hashString(paletteKey));
+  const gradient = createGradient(palette);
+  const scratch = [0, 0, 0];
+
+  function hashString(str) {
+    let h = 1779033703 ^ (str.length || 1);
+    for (let i = 0; i < str.length; i++) {
+      h = Math.imul(h ^ str.charCodeAt(i), 3432918353);
+      h = (h << 13) | (h >>> 19);
+    }
+    return (h ^ (h >>> 16)) >>> 0;
+  }
+
+  function mulberry32(a) {
+    return () => {
+      a |= 0;
+      a = a + 0x6d2b79f5 | 0;
+      let t = Math.imul(a ^ (a >>> 15), 1 | a);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+  }
+
+  function createSimplexNoise(seed) {
+    const F2 = 0.3660254037844386; // (Math.sqrt(3) - 1) / 2
+    const G2 = 0.21132486540518713; // (3 - Math.sqrt(3)) / 6
+    const grad3 = new Float32Array([
+      1, 1, 0, -1, 1, 0, 1, -1, 0, -1, -1, 0,
+      1, 0, 1, -1, 0, 1, 1, 0, -1, -1, 0, -1,
+      0, 1, 1, 0, -1, 1, 0, 1, -1, 0, -1, -1
+    ]);
+    const random = mulberry32(seed);
+    const p = new Uint8Array(256);
+    for (let i = 0; i < 256; i++) p[i] = i;
+    for (let i = 255; i >= 0; i--) {
+      const r = Math.floor(random() * (i + 1));
+      const tmp = p[i];
+      p[i] = p[r];
+      p[r] = tmp;
+    }
+    const perm = new Uint8Array(512);
+    for (let i = 0; i < 512; i++) perm[i] = p[i & 255];
+
+    return (xin, yin) => {
+      let n0 = 0, n1 = 0, n2 = 0;
+      const s = (xin + yin) * F2;
+      const i = Math.floor(xin + s);
+      const j = Math.floor(yin + s);
+      const t = (i + j) * G2;
+      const X0 = i - t;
+      const Y0 = j - t;
+      const x0 = xin - X0;
+      const y0 = yin - Y0;
+
+      const i1 = x0 > y0 ? 1 : 0;
+      const j1 = x0 > y0 ? 0 : 1;
+
+      const x1 = x0 - i1 + G2;
+      const y1 = y0 - j1 + G2;
+      const x2 = x0 - 1 + 2 * G2;
+      const y2 = y0 - 1 + 2 * G2;
+
+      const ii = i & 255;
+      const jj = j & 255;
+      const gi0 = perm[ii + perm[jj]] % 12;
+      const gi1 = perm[ii + i1 + perm[jj + j1]] % 12;
+      const gi2 = perm[ii + 1 + perm[jj + 1]] % 12;
+
+      let t0 = 0.5 - x0 * x0 - y0 * y0;
+      if (t0 >= 0) {
+        t0 *= t0;
+        n0 = t0 * t0 * (grad3[gi0 * 3] * x0 + grad3[gi0 * 3 + 1] * y0);
+      }
+      let t1 = 0.5 - x1 * x1 - y1 * y1;
+      if (t1 >= 0) {
+        t1 *= t1;
+        n1 = t1 * t1 * (grad3[gi1 * 3] * x1 + grad3[gi1 * 3 + 1] * y1);
+      }
+      let t2 = 0.5 - x2 * x2 - y2 * y2;
+      if (t2 >= 0) {
+        t2 *= t2;
+        n2 = t2 * t2 * (grad3[gi2 * 3] * x2 + grad3[gi2 * 3 + 1] * y2);
+      }
+      return 70 * (n0 + n1 + n2);
+    };
+  }
+
+  function hexToRgb(hex) {
+    const raw = hex.replace('#', '');
+    const norm = raw.length === 3 ? raw.split('').map((c) => c + c).join('') : raw;
+    const num = parseInt(norm, 16);
+    return [
+      (num >> 16) & 255,
+      (num >> 8) & 255,
+      num & 255
+    ];
+  }
+
+  function createGradient(colors) {
+    const palette = colors.length ? colors : paletteMap.default;
+    const stops = palette.map((color, index) => ({
+      pos: palette.length > 1 ? index / (palette.length - 1) : 0,
+      rgb: hexToRgb(color)
+    }));
+    return (t, out) => {
+      const target = out || [0, 0, 0];
+      const clamped = Math.min(1, Math.max(0, t));
+      if (stops.length === 1) {
+        const [r, g, b] = stops[0].rgb;
+        target[0] = r;
+        target[1] = g;
+        target[2] = b;
+        return target;
+      }
+      for (let i = 1; i < stops.length; i++) {
+        const prev = stops[i - 1];
+        const next = stops[i];
+        if (clamped <= next.pos) {
+          const localT = (clamped - prev.pos) / Math.max(1e-5, next.pos - prev.pos);
+          target[0] = Math.round(prev.rgb[0] + (next.rgb[0] - prev.rgb[0]) * localT);
+          target[1] = Math.round(prev.rgb[1] + (next.rgb[1] - prev.rgb[1]) * localT);
+          target[2] = Math.round(prev.rgb[2] + (next.rgb[2] - prev.rgb[2]) * localT);
+          return target;
+        }
+      }
+      const last = stops[stops.length - 1].rgb;
+      target[0] = last[0];
+      target[1] = last[1];
+      target[2] = last[2];
+      return target;
+    };
+  }
+
+  function ensureSampleBuffer(force = false) {
+    if (!width || !height) return;
+    const targetW = Math.max(160, Math.round(width / 6));
+    const targetH = Math.max(120, Math.round(height / 6));
+    if (!imageData || force || targetW !== sampleW || targetH !== sampleH) {
+      sampleW = targetW;
+      sampleH = targetH;
+      sampleCanvas.width = sampleW;
+      sampleCanvas.height = sampleH;
+      imageData = sampleCtx.createImageData(sampleW, sampleH);
+    }
+  }
+
+  function drawFrame(timeMs) {
+    if (!imageData) return;
+    const data = imageData.data;
+    const time = (timeMs || 0) * 0.00008;
+    let offset = 0;
+    for (let y = 0; y < sampleH; y++) {
+      const ny = y / sampleH;
+      const centeredY = (ny - 0.5) * 2;
+      for (let x = 0; x < sampleW; x++, offset += 4) {
+        const nx = x / sampleW;
+        const centeredX = (nx - 0.5) * 2;
+        let amplitude = 1;
+        let frequency = 0.65;
+        let total = 0;
+        let ampSum = 0;
+        for (let octave = 0; octave < 3; octave++) {
+          const sample = noise(centeredX * frequency + time * 0.9, centeredY * frequency + time * 0.7);
+          total += (sample * 0.5 + 0.5) * amplitude;
+          ampSum += amplitude;
+          amplitude *= 0.55;
+          frequency *= 1.9;
+        }
+        let shade = ampSum ? total / ampSum : 0;
+        const dx = centeredX * 0.6;
+        const dy = centeredY * 0.6;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        const falloff = Math.max(0, 1 - dist * 1.35);
+        const ribbon = noise(centeredX * 0.4 + time * 0.35, centeredY * 0.4 - time * 0.28) * 0.5 + 0.5;
+        shade = Math.min(1, Math.max(0, shade * 0.65 + falloff * 0.35 + ribbon * 0.2));
+        const color = gradient(Math.pow(shade, 0.85), scratch);
+        data[offset] = color[0];
+        data[offset + 1] = color[1];
+        data[offset + 2] = color[2];
+        data[offset + 3] = Math.round(140 + shade * 110);
+      }
+    }
+    sampleCtx.putImageData(imageData, 0, 0);
+    ctx.clearRect(0, 0, width, height);
+    ctx.imageSmoothingEnabled = true;
+    ctx.drawImage(sampleCanvas, 0, 0, width, height);
+  }
+
+  function renderFrame(time) {
+    drawFrame(time);
+    if (!mq.matches) {
+      animId = requestAnimationFrame(renderFrame);
+    }
+  }
+
+  function stop() {
+    if (animId != null) {
+      cancelAnimationFrame(animId);
+      animId = null;
+    }
+  }
+
+  function start() {
+    stop();
+    ensureSampleBuffer();
+    if (mq.matches) {
+      drawFrame(0);
+    } else {
+      animId = requestAnimationFrame(renderFrame);
+    }
+  }
+
+  function resize() {
+    width = canvas.clientWidth = window.innerWidth;
+    height = canvas.clientHeight = window.innerHeight;
+    canvas.width = width * DPR;
+    canvas.height = height * DPR;
+    ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+    ensureSampleBuffer(true);
+    if (mq.matches) {
+      drawFrame(0);
+    }
+  }
+
+  window.addEventListener('resize', () => {
+    resize();
+  }, { passive: true });
+  mq.addEventListener?.('change', start);
+  mq.addListener?.(() => start());
+
+  resize();
+  start();
+})();
+
+
+(() => {
   
   const canvas = document.getElementById('stars');
   if (!canvas) return;
@@ -9,13 +277,13 @@
 
   let w, h, stars = [];
   const STAR_COUNT = 760;
-  const SPEED = 0.004;
+  const SPEED = 0.0008;
   let animId;
   let lastTime = null;
 
-  function resetStar(z = Math.random() * 0.9 + 0.1) {
+  function resetStar(z = Math.random() * 0.7 + 0.3) {
     const theta = Math.random() * Math.PI * 2;
-    const radius = Math.sqrt(Math.random()) * 0.5;
+    const radius = Math.pow(Math.random(), 1.6) * 0.45;
 
     return {
       x: Math.cos(theta) * radius,
@@ -79,6 +347,7 @@
 
   window.addEventListener('resize', resize, { passive: true });
   mq.addEventListener?.('change', () => (mq.matches ? stop() : start()));
+  mq.addListener?.(() => (mq.matches ? stop() : start()));
   resize();
   start();
 })();

--- a/pages/b2b.html
+++ b/pages/b2b.html
@@ -10,7 +10,9 @@
 <link rel="canonical" href="https://evera.world/b2b">
 <link rel="stylesheet" href="/Evera/css/styles.css">
 </head>
-<body>
+<body data-nebula="b2b">
+<canvas id="nebula" aria-hidden="true"></canvas>
+<canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <nav class="nav">
     <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>

--- a/pages/book.html
+++ b/pages/book.html
@@ -10,7 +10,9 @@
 <link rel="canonical" href="https://evera.world/book">
 <link rel="stylesheet" href="/Evera/css/styles.css">
 </head>
-<body>
+<body data-nebula="book">
+<canvas id="nebula" aria-hidden="true"></canvas>
+<canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <nav class="nav">
     <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>

--- a/pages/cases.html
+++ b/pages/cases.html
@@ -10,7 +10,9 @@
 <link rel="canonical" href="https://evera.world/cases">
 <link rel="stylesheet" href="/Evera/css/styles.css">
 </head>
-<body>
+<body data-nebula="cases">
+<canvas id="nebula" aria-hidden="true"></canvas>
+<canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <nav class="nav">
     <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>

--- a/pages/eternals.html
+++ b/pages/eternals.html
@@ -10,7 +10,9 @@
 <link rel="canonical" href="https://evera.world/eternals">
 <link rel="stylesheet" href="/Evera/css/styles.css">
 </head>
-<body>
+<body data-nebula="eternals">
+<canvas id="nebula" aria-hidden="true"></canvas>
+<canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <nav class="nav">
     <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>

--- a/pages/methodology.html
+++ b/pages/methodology.html
@@ -10,7 +10,9 @@
 <link rel="canonical" href="https://evera.world/methodology">
 <link rel="stylesheet" href="/Evera/css/styles.css">
 </head>
-<body>
+<body data-nebula="methodology">
+<canvas id="nebula" aria-hidden="true"></canvas>
+<canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <nav class="nav">
     <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>

--- a/pages/roadmap.html
+++ b/pages/roadmap.html
@@ -10,7 +10,9 @@
 <link rel="canonical" href="https://evera.world/roadmap">
 <link rel="stylesheet" href="/Evera/css/styles.css">
 </head>
-<body>
+<body data-nebula="roadmap">
+<canvas id="nebula" aria-hidden="true"></canvas>
+<canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <nav class="nav">
     <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>

--- a/pages/team.html
+++ b/pages/team.html
@@ -10,7 +10,9 @@
 <link rel="canonical" href="https://evera.world/team">
 <link rel="stylesheet" href="/Evera/css/styles.css">
 </head>
-<body>
+<body data-nebula="team">
+<canvas id="nebula" aria-hidden="true"></canvas>
+<canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <nav class="nav">
     <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>


### PR DESCRIPTION
## Summary
- add the nebula canvas layer and palette metadata to the home page and interior views
- render a simplex-noise nebula keyed to each palette with a reduced-motion fallback
- slow the starfield drift and introduce supporting CSS for the blended nebula

## Testing
- No automated tests (static site)


------
https://chatgpt.com/codex/tasks/task_e_68de521e41a8832f9afa9674e6d0b132