### PR TITLE
Add pricing landing pages and CTA wiring

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -168,6 +168,76 @@ main{display:block;overflow-x:hidden}
   margin-top:20px;
 }
 
+.pricing-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
+  gap:22px;
+  margin-top:24px;
+}
+
+.tariff-card{
+  background:var(--card);
+  border:1px solid rgba(255,255,255,.12);
+  border-radius:20px;
+  padding:26px 24px;
+  box-shadow:var(--shadow);
+  display:flex;
+  flex-direction:column;
+  gap:14px;
+  position:relative;
+}
+
+.tariff-card.is-popular{
+  border:1px solid rgba(125,230,200,.55);
+  background:linear-gradient(180deg,rgba(157,214,255,.18),rgba(8,31,43,.75));
+  box-shadow:0 22px 42px rgba(10,49,63,.28);
+}
+
+.tariff-card .tag{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:8px 16px;
+  border-radius:999px;
+  background:rgba(255,255,255,.08);
+  border:1px solid rgba(255,255,255,.14);
+  font-size:14px;
+  font-weight:600;
+  letter-spacing:.04em;
+  text-transform:uppercase;
+  width:max-content;
+}
+
+.tariff-card.is-popular .tag{
+  background:rgba(125,230,200,.15);
+  border-color:rgba(125,230,200,.5);
+  color:var(--text);
+}
+
+.tariff-card .price{
+  font-size:34px;
+  font-weight:700;
+  color:var(--text);
+  letter-spacing:-.01em;
+}
+
+.tariff-card .meta{
+  font-size:15px;
+  color:var(--muted);
+}
+
+.tariff-card ul{
+  margin:0;
+  padding-left:18px;
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+
+.tariff-card ul li{line-height:1.5;}
+
+.tariff-card .btn{margin-top:auto;}
+
 .card{
   background:var(--card);
   border:1px solid rgba(255,255,255,.08);
@@ -310,6 +380,15 @@ main{display:block;overflow-x:hidden}
 }
 
 .cta-block .btn{margin-top:10px;}
+
+.cta-actions{
+  display:flex;
+  flex-wrap:wrap;
+  gap:12px;
+  margin-top:16px;
+}
+
+.cta-actions .btn{margin-top:0;}
 
 /* Process steps */
 .process{

--- a/en/pages/pricing.html
+++ b/en/pages/pricing.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>EVERA Pricing — Base, Pro, Legacy plans</title>
+<meta name="description" content="Explore EVERA pricing: Base, Pro, and Legacy plans covering interviews, analytics, dialogue AI, and curator support.">
+<link rel="icon" href="/Evera/assets/icons/favicon.svg">
+<link rel="alternate" hreflang="en" href="/Evera/en/pages/pricing.html">
+<link rel="alternate" hreflang="ru" href="/Evera/pages/pricing.html?lang=ru">
+<link rel="canonical" href="https://evera.world/en/pricing">
+<link rel="stylesheet" href="/Evera/css/styles.css">
+</head>
+<body>
+<header class="header">
+  <nav class="nav">
+    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+    <div class="links">
+      <a class="btn" href="/Evera/index.html">Home</a>
+      <a class="btn" href="/Evera/pages/methodology.html?lang=en">Methodology</a>
+      <a class="btn" href="/Evera/pages/cases.html?lang=en">Cases</a>
+      <a class="btn" href="/Evera/pages/team.html?lang=en">Team</a>
+      <a class="btn" href="/Evera/pages/roadmap.html?lang=en">Roadmap</a>
+      <a class="btn" href="/Evera/pages/book.html?lang=en">Book of Life</a>
+      <a class="btn" href="/Evera/pages/b2b.html?lang=en">B2B</a>
+      <a class="btn" href="/Evera/pages/eternals.html?lang=en">Eternals</a>
+      <a class="btn" href="/Evera/en/pages/pricing.html">Pricing</a>
+      <select class="lang-switch" aria-label="Switch language"><option value="en" selected>EN</option><option value="ru">RU</option></select>
+    </div>
+  </nav>
+</header>
+<main>
+  <article class="page-intro" data-lang="ru" lang="ru" hidden>
+    <section class="section">
+      <div class="container">
+        <h1>Тарифы EVERA</h1>
+        <p class="lead">Русская версия страницы доступна по ссылке ниже.</p>
+        <div class="cta-block">
+          <div class="cta-actions">
+            <a class="btn" href="/Evera/pages/pricing.html">Открыть тарифы на русском</a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </article>
+  <article class="page-intro" data-lang="en" lang="en">
+    <section class="section">
+      <div class="container">
+        <h1>EVERA Pricing</h1>
+        <p class="lead">Choose the format that fits your legacy: from a family Book of Life to a corporate knowledge base with conversational AI. Every plan combines interviews, analytics, and curator-guided launch.</p>
+        <div class="pill-list"><span>150+ prompts</span><span>AI archive</span><span>Dialogue access</span><span>Editorial team</span></div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Plans</div>
+        <h2>Select your configuration</h2>
+        <div class="pricing-grid">
+          <div class="tariff-card">
+            <span class="tag">Base</span>
+            <div class="price">120,000&nbsp;₽</div>
+            <p class="meta">6 weeks, one protagonist, digital Book of Life delivery.</p>
+            <ul>
+              <li>Up to three interviews (remote or on-site) with 150+ prompts.</li>
+              <li>Speech, emotion, and theme analytics with curator notes.</li>
+              <li>Digital Book of Life (PDF) with timeline, quotes, and media.</li>
+              <li>Foundational dialogue model with private family access.</li>
+            </ul>
+            <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20Base%20—%20Request%20a%20quote">Request a quote</a>
+          </div>
+          <div class="tariff-card is-popular">
+            <span class="tag">Pro</span>
+            <div class="price">280,000&nbsp;₽</div>
+            <p class="meta">3 months, up to three protagonists, extended AI dialogue and family archive.</p>
+            <ul>
+              <li>Up to six interviews plus bonus sessions with relatives or partners.</li>
+              <li>Advanced analytics: timelines, genealogy, semantic mapping.</li>
+              <li>Dialogue AI with themed modes and citation links to sources.</li>
+              <li>Family portal with access governance and onboarding workshop.</li>
+            </ul>
+            <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20Pro%20—%20Request%20a%20quote">Request a quote</a>
+          </div>
+          <div class="tariff-card">
+            <span class="tag">Legacy</span>
+            <div class="price">520,000&nbsp;₽</div>
+            <p class="meta">6 months, 3+ protagonists, printed edition and long-term portrait stewardship.</p>
+            <ul>
+              <li>Full editorial expedition with on-site recording and archive digitisation.</li>
+              <li>Printed Book of Life plus interactive edition with QR-linked media.</li>
+              <li>Private dialogue AI with moderator oversight and rolling updates.</li>
+              <li>12 months of curation with options for corporate or museum scenarios.</li>
+            </ul>
+            <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20Legacy%20—%20Request%20a%20quote">Request a quote</a>
+          </div>
+        </div>
+        <div class="cta-block">
+          <p>Have a special project in mind — a memorial museum, bilingual archive, or enterprise deployment? We will scope a custom offer and assign a curator within two business days.</p>
+          <div class="cta-actions">
+            <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20—%20Request%20a%20quote">Request a quote</a>
+            <a class="btn ghost" href="https://t.me/Solo013" target="_blank" rel="noopener">Chat on Telegram</a>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Included</div>
+        <h2>Every plan covers</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Interviews & materials</h3>
+            <p>We design the script, conduct interviews, and digitise letters, photos, and videos.</p>
+          </div>
+          <div class="card">
+            <h3>Analysis & editing</h3>
+            <p>We extract narratives, emotions, and lexicon to craft the Book of Life and knowledge base.</p>
+          </div>
+          <div class="card">
+            <h3>Dialogue AI</h3>
+            <p>We configure a conversational portrait with trustworthy citations and flexible access.</p>
+          </div>
+          <div class="card">
+            <h3>Support</h3>
+            <p>We train the family or team, refresh the model, and help integrate it into daily scenarios.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </article>
+</main>
+<footer class="footer"><div class="small">© 2025 EVERA</div></footer>
+<script src="/Evera/js/app.js"></script>
+</body></html>

--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
         <a href="#eternals">Вечные</a>
         <a href="#audience">Для кого</a>
         <a href="#b2b">Бизнес</a>
+        <a href="/Evera/pages/pricing.html">Тарифы</a>
         <a href="#ethics">Этика</a>
         <a href="#faq">FAQ</a>
       </div>
@@ -202,6 +203,14 @@
             компании и лидеров.</li>
           <li><strong>CSR и HR‑бренд</strong> — публичные версии для карьеры, образовательных партнёрств и медиа.</li>
         </ul>
+        <div class="cta-block">
+          <p>Смотрите тарифы EVERA или получите индивидуальный расчёт — команда ответит на почту и в Telegram.</p>
+          <div class="cta-actions">
+            <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20—%20Запрос%20расчёта">Запросить расчёт</a>
+            <a class="btn" href="/Evera/pages/pricing.html">Тарифы EVERA</a>
+            <a class="btn ghost" href="https://t.me/Solo013" target="_blank" rel="noopener">Telegram</a>
+          </div>
+        </div>
       </div>
     </section>
 
@@ -321,6 +330,7 @@
         </div>
         <div>
           <p class="small">Контакты: <a href="https://t.me/Solo013" target="_blank" rel="noopener">t.me/Solo013</a></p>
+          <p class="small"><a href="/Evera/pages/pricing.html">Тарифы</a> · <a href="/Evera/en/pages/pricing.html">Pricing</a></p>
           <p class="small"><a href="/sitemap.xml">sitemap</a> · <a href="/robots.txt">robots</a></p>
         </div>
       </div>

--- a/js/app.js
+++ b/js/app.js
@@ -147,7 +147,8 @@
       roadmap: { ru: 'Дорожная карта', en: 'Roadmap' },
       book: { ru: 'Книга Жизни', en: 'Book of Life' },
       b2b: { ru: 'B2B', en: 'B2B' },
-      eternals: { ru: 'Вечные', en: 'Eternals' }
+      eternals: { ru: 'Вечные', en: 'Eternals' },
+      pricing: { ru: 'Тарифы', en: 'Pricing' }
     }
   };
 
@@ -175,6 +176,12 @@
     document.querySelectorAll('[data-i18n]').forEach((node) => {
       const value = localizedText(node.dataset.i18n, normalized);
       if (value) node.textContent = value;
+    });
+    document.querySelectorAll('[data-href-ru],[data-href-en]').forEach((node) => {
+      if (!(node instanceof HTMLElement)) return;
+      const { hrefRu, hrefEn } = node.dataset;
+      if (normalized === 'ru' && hrefRu) node.setAttribute('href', hrefRu);
+      if (normalized === 'en' && hrefEn) node.setAttribute('href', hrefEn);
     });
     switchers.forEach((sw) => { sw.value = normalized; });
   };

--- a/pages/b2b.html
+++ b/pages/b2b.html
@@ -23,6 +23,7 @@
       <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
       <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
       <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="/Evera/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/Evera/pages/pricing.html" data-href-en="/Evera/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
@@ -116,8 +117,12 @@
           </div>
         </div>
         <div class="cta-block">
-          <p>Опишите задачи бизнеса — подготовим предложение с бюджетом и таймлайном в течение пяти рабочих дней.</p>
-          <a class="btn" href="mailto:b2b@evera.world">Запросить предложение</a>
+          <p>Посмотрите тарифы EVERA и обсудите индивидуальный расчёт для вашей команды.</p>
+          <div class="cta-actions">
+            <a class="btn" href="mailto:b2b@evera.world?subject=EVERA%20B2B%20—%20Запрос%20расчёта">Запросить расчёт</a>
+            <a class="btn" href="/Evera/pages/pricing.html" data-href-ru="/Evera/pages/pricing.html" data-href-en="/Evera/en/pages/pricing.html">Тарифы EVERA</a>
+            <a class="btn ghost" href="https://t.me/Solo013" target="_blank" rel="noopener">Telegram</a>
+          </div>
         </div>
       </div>
     </section>
@@ -210,8 +215,12 @@
           </div>
         </div>
         <div class="cta-block">
-          <p>Share your business goals and we will craft a proposal with budget and timeline within five working days.</p>
-          <a class="btn" href="mailto:b2b@evera.world">Request a proposal</a>
+          <p>Explore EVERA pricing or reach out for a bespoke scope tailored to your organisation.</p>
+          <div class="cta-actions">
+            <a class="btn" href="mailto:b2b@evera.world?subject=EVERA%20B2B%20—%20Request%20a%20quote">Request a quote</a>
+            <a class="btn" href="/Evera/en/pages/pricing.html">EVERA Pricing</a>
+            <a class="btn ghost" href="https://t.me/Solo013" target="_blank" rel="noopener">Telegram</a>
+          </div>
         </div>
       </div>
     </section>

--- a/pages/book.html
+++ b/pages/book.html
@@ -23,6 +23,7 @@
       <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
       <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
       <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="/Evera/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/Evera/pages/pricing.html" data-href-en="/Evera/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>

--- a/pages/cases.html
+++ b/pages/cases.html
@@ -23,6 +23,7 @@
       <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
       <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
       <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="/Evera/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/Evera/pages/pricing.html" data-href-en="/Evera/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>

--- a/pages/eternals.html
+++ b/pages/eternals.html
@@ -23,6 +23,7 @@
       <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
       <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
       <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="/Evera/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/Evera/pages/pricing.html" data-href-en="/Evera/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>

--- a/pages/methodology.html
+++ b/pages/methodology.html
@@ -23,6 +23,7 @@
       <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
       <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
       <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="/Evera/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/Evera/pages/pricing.html" data-href-en="/Evera/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>

--- a/pages/pricing.html
+++ b/pages/pricing.html
@@ -1,0 +1,203 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Тарифы EVERA — цифровое наследие под ключ</title>
+<meta name="description" content="Тарифы EVERA: Base, Pro и Legacy. Интервью, аналитика, диалоговый ИИ и сопровождение для семей и брендов.">
+<link rel="icon" href="/Evera/assets/icons/favicon.svg">
+<link rel="alternate" hreflang="ru" href="/Evera/pages/pricing.html?lang=ru">
+<link rel="alternate" hreflang="en" href="/Evera/en/pages/pricing.html">
+<link rel="canonical" href="https://evera.world/pricing">
+<link rel="stylesheet" href="/Evera/css/styles.css">
+</head>
+<body>
+<header class="header">
+  <nav class="nav">
+    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+    <div class="links">
+      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Главная</a>
+      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
+      <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
+      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="/Evera/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/Evera/pages/pricing.html" data-href-en="/Evera/en/pages/pricing.html">Тарифы</a>
+      <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
+    </div>
+  </nav>
+</header>
+<main>
+  <article class="page-intro" data-lang="ru" lang="ru">
+    <section class="section">
+      <div class="container">
+        <h1>Тарифы EVERA</h1>
+        <p class="lead">Подберём формат под задачу: от семейной «Книги Жизни» до корпоративной базы знаний с диалоговым ИИ. Каждый тариф включает интервью, аналитику и сопровождение запуска.</p>
+        <div class="pill-list"><span>150+ вопросов</span><span>ИИ-архив</span><span>Диалоговый доступ</span><span>Редакция</span></div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Тарифы</div>
+        <h2>Выберите конфигурацию</h2>
+        <div class="pricing-grid">
+          <div class="tariff-card">
+            <span class="tag">Base</span>
+            <div class="price">120&nbsp;000&nbsp;₽</div>
+            <p class="meta">6 недель, 1 герой, готовая «Книга Жизни» в цифровом формате.</p>
+            <ul>
+              <li>До 3 интервью (онлайн/офлайн) по 150+ вопросам.</li>
+              <li>Аналитика речи, эмоций и тематических кластеров.</li>
+              <li>Цифровая «Книга Жизни» (PDF) с хроникой и цитатами.</li>
+              <li>Базовый диалоговый модуль с доступом для семьи.</li>
+            </ul>
+            <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20Base%20—%20Запрос%20расчёта">Запросить расчёт</a>
+          </div>
+          <div class="tariff-card is-popular">
+            <span class="tag">Pro</span>
+            <div class="price">280&nbsp;000&nbsp;₽</div>
+            <p class="meta">3 месяца, до 3 героев, расширенный диалоговый ИИ и семейный архив.</p>
+            <ul>
+              <li>До 6 интервью с доп. сессиями для родственников.</li>
+              <li>Расширенная аналитика: таймлайны, генеалогия, карта смыслов.</li>
+              <li>Диалоговый ИИ с тематическими режимами и ссылками на источники.</li>
+              <li>Семейный портал с доступами и onboarding сессией.</li>
+            </ul>
+            <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20Pro%20—%20Запрос%20расчёта">Запросить расчёт</a>
+          </div>
+          <div class="tariff-card">
+            <span class="tag">Legacy</span>
+            <div class="price">520&nbsp;000&nbsp;₽</div>
+            <p class="meta">6 месяцев, 3+ героя, печатное издание и пожизненное сопровождение портрета.</p>
+            <ul>
+              <li>Полная редакционная экспедиция, выездная запись и оцифровка архива.</li>
+              <li>Печатная «Книга Жизни» + интерактивное издание с QR-кодами.</li>
+              <li>Закрытый диалоговый ИИ с персональной модерацией и обновлениями.</li>
+              <li>12 месяцев кураторства и расширение под корпоративные сценарии.</li>
+            </ul>
+            <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20Legacy%20—%20Запрос%20расчёта">Запросить расчёт</a>
+          </div>
+        </div>
+        <div class="cta-block">
+          <p>Нужен нестандартный сценарий: мемориальный музей, корпоративная память или семейный архив на нескольких языках? Подготовим индивидуальный расчёт и подключим куратора.</p>
+          <div class="cta-actions">
+            <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20—%20Запрос%20расчёта">Запросить расчёт</a>
+            <a class="btn ghost" href="https://t.me/Solo013" target="_blank" rel="noopener">Связаться в&nbsp;Telegram</a>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Что включено</div>
+        <h2>Каждый тариф содержит</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Интервью и сбор материалов</h3>
+            <p>Составляем сценарий, проводим интервью и оцифровываем семейные артефакты: письма, фото, видео.</p>
+          </div>
+          <div class="card">
+            <h3>Аналитика и редактура</h3>
+            <p>Выделяем сюжетные линии, эмоции и лексику, формируем структуру «Книги Жизни» и базы знаний.</p>
+          </div>
+          <div class="card">
+            <h3>Диалоговый ИИ</h3>
+            <p>Настраиваем виртуального собеседника с проверяемыми ссылками и гибким управлением доступом.</p>
+          </div>
+          <div class="card">
+            <h3>Поддержка</h3>
+            <p>Обучаем семью или команду, обновляем модель, помогаем интегрировать портрет в выбранные сценарии.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </article>
+  <article class="page-intro" data-lang="en" lang="en" hidden>
+    <section class="section">
+      <div class="container">
+        <h1>EVERA Pricing</h1>
+        <p class="lead">Choose the format that fits your story: from a family Book of Life to a corporate knowledge base with conversational AI. Every tier bundles interviews, analytics, and guided launch.</p>
+        <div class="pill-list"><span>150+ prompts</span><span>AI archive</span><span>Dialogue access</span><span>Editorial team</span></div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Plans</div>
+        <h2>Select your configuration</h2>
+        <div class="pricing-grid">
+          <div class="tariff-card">
+            <span class="tag">Base</span>
+            <div class="price">120,000&nbsp;₽</div>
+            <p class="meta">6 weeks, one protagonist, digital Book of Life delivery.</p>
+            <ul>
+              <li>Up to three interviews (remote/on-site) covering 150+ prompts.</li>
+              <li>Speech, emotion, and theme analytics with curator notes.</li>
+              <li>Digital Book of Life (PDF) with timeline, quotes, and media.</li>
+              <li>Foundational dialogue model with private family access.</li>
+            </ul>
+            <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20Base%20—%20Request%20a%20quote">Request a quote</a>
+          </div>
+          <div class="tariff-card is-popular">
+            <span class="tag">Pro</span>
+            <div class="price">280,000&nbsp;₽</div>
+            <p class="meta">3 months, up to three protagonists, extended AI dialogue and family archive.</p>
+            <ul>
+              <li>Up to six interviews plus bonus sessions with relatives or partners.</li>
+              <li>Advanced analytics: timelines, genealogy, semantic mapping.</li>
+              <li>Dialogue AI with themed modes and citation links to sources.</li>
+              <li>Family portal with access management and onboarding workshop.</li>
+            </ul>
+            <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20Pro%20—%20Request%20a%20quote">Request a quote</a>
+          </div>
+          <div class="tariff-card">
+            <span class="tag">Legacy</span>
+            <div class="price">520,000&nbsp;₽</div>
+            <p class="meta">6 months, 3+ protagonists, printed edition and long-term portrait stewardship.</p>
+            <ul>
+              <li>Full editorial expedition with on-site recording and archive digitisation.</li>
+              <li>Printed Book of Life plus interactive edition with QR-linked media.</li>
+              <li>Private dialogue AI with moderator oversight and rolling updates.</li>
+              <li>12 months of curation with options for corporate or museum scenarios.</li>
+            </ul>
+            <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20Legacy%20—%20Request%20a%20quote">Request a quote</a>
+          </div>
+        </div>
+        <div class="cta-block">
+          <p>Have a special project in mind — a memorial museum, bilingual archive, or enterprise deployment? We will scope a custom offer and assign a curator within two business days.</p>
+          <div class="cta-actions">
+            <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20—%20Request%20a%20quote">Request a quote</a>
+            <a class="btn ghost" href="https://t.me/Solo013" target="_blank" rel="noopener">Chat on Telegram</a>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Included</div>
+        <h2>Every plan covers</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Interviews & materials</h3>
+            <p>We design the script, conduct interviews, and digitise letters, photos, and videos.</p>
+          </div>
+          <div class="card">
+            <h3>Analysis & editing</h3>
+            <p>We extract narratives, emotions, and lexicon to craft the Book of Life and knowledge base.</p>
+          </div>
+          <div class="card">
+            <h3>Dialogue AI</h3>
+            <p>We configure a conversational portrait with trustworthy citations and flexible access.</p>
+          </div>
+          <div class="card">
+            <h3>Support</h3>
+            <p>We train the family or team, refresh the model, and help integrate it into daily scenarios.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </article>
+</main>
+<footer class="footer"><div class="small">© 2025 EVERA</div></footer>
+<script src="/Evera/js/app.js"></script>
+</body></html>

--- a/pages/roadmap.html
+++ b/pages/roadmap.html
@@ -23,6 +23,7 @@
       <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
       <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
       <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="/Evera/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/Evera/pages/pricing.html" data-href-en="/Evera/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>

--- a/pages/team.html
+++ b/pages/team.html
@@ -23,6 +23,7 @@
       <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
       <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
       <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="/Evera/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/Evera/pages/pricing.html" data-href-en="/Evera/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,5 @@
 User-agent: *
 Allow: /
+Allow: /pricing
+Allow: /en/pricing
 Sitemap: https://evera.world/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -8,4 +8,6 @@
   <url><loc>https://evera.world/book</loc></url>
   <url><loc>https://evera.world/b2b</loc></url>
   <url><loc>https://evera.world/eternals</loc></url>
+  <url><loc>https://evera.world/pricing</loc></url>
+  <url><loc>https://evera.world/en/pricing</loc></url>
 </urlset>


### PR DESCRIPTION
## Summary
- add a dedicated Russian pricing page with Base/Pro/Legacy cards, intro copy, and quote/Telegram CTAs
- ship an English pricing counterpart and enable language-aware navigation plus CTA updates across secondary pages and the homepage
- surface the new pricing URLs in navigation, footer, sitemap, and robots.txt

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68de52237b7c832faa05f4f2bba2e969