### PR TITLE
Use relative asset paths for GitHub Pages hosting

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Страница не найдена — EVERA</title>
-  <link rel="icon" href="/evera-logo-white.svg">
-  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="icon" href="./evera-logo-white.svg">
+  <link rel="stylesheet" href="./css/styles.css">
   <style>.hero{padding:120px 0 60px;text-align:center}</style>
 </head>
 <body>
@@ -14,10 +14,10 @@
     <h1>404 — портал сюда не ведёт</h1>
     <p class="lead">Такой страницы у нас нет. Возможно, она ещё строится в звёздной пыли.</p>
     <div class="cta">
-      <a class="btn" href="/">На главную</a>
-      <a class="btn ghost" href="/pages/book.html">Книга Жизни</a>
+      <a class="btn" href="./">На главную</a>
+      <a class="btn ghost" href="./pages/book.html">Книга Жизни</a>
     </div>
   </main>
-  <script src="/js/app.js"></script>
+  <script src="./js/app.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -15,15 +15,15 @@
   <meta name="keywords" content="цифровое бессмертие, цифровой портрет, оцифровка памяти, цифровое наследие, Книга Жизни, Библиотека Вечных, голосовой портрет, 150 вопросов, лексика и эмоции, этика и безопасность">
   <!-- Favicon & manifest -->
   <!-- Use relative paths so the site works on GitHub Pages and custom domains -->
-  <link rel="icon" href="evera-logo-white.svg">
-  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="./evera-logo-white.svg">
+  <link rel="manifest" href="./manifest.json">
   <!-- OpenGraph tags -->
   <meta property="og:title" content="EVERA — цифровое бессмертие и оцифровка личности">
   <meta property="og:description" content="Интервью 150+ вопросов, анализ речи и эмоций, Книга Жизни и Библиотека Вечных. Создайте цифровое наследие для семьи, бизнеса и культуры.">
-       <meta property="og:image" content="evera-logo-white.png">
+       <meta property="og:image" content="./evera-logo-white.png">
   <meta property="og:type" content="website">
   <!-- Stylesheet for this page -->
-  <link rel="stylesheet" href="css/styles.css">
+  <link rel="stylesheet" href="./css/styles.css">
 </head>
 <body>
   <!-- Звёздное небо на фоне. Canvas размещён под контентом. -->
@@ -33,7 +33,7 @@
   <header class="header">
     <div class="nav container">
       <a class="logo" href="#" aria-label="EVERA">
-        <img src="evera-logo-white.svg" alt="EVERA logo">
+        <img src="./evera-logo-white.svg" alt="EVERA logo">
       </a>
       <!-- Кнопка меню для мобильной версии -->
       <button id="menuToggle" class="menu-toggle" aria-label="Меню">☰</button>
@@ -321,7 +321,7 @@
         </div>
         <div>
           <p class="small">Контакты: <a href="https://t.me/Solo013" target="_blank" rel="noopener">t.me/Solo013</a></p>
-          <p class="small"><a href="/sitemap.xml">sitemap</a> · <a href="/robots.txt">robots</a></p>
+          <p class="small"><a href="./sitemap.xml">sitemap</a> · <a href="./robots.txt">robots</a></p>
         </div>
       </div>
       <div class="copy">© 2025 EVERA · No ads · No trackers</div>
@@ -329,6 +329,6 @@
   </footer>
 
   <!-- Главный скрипт: звёзды, модальное окно, reveal-анимации -->
-  <script src="js/app.js"></script>
+  <script src="./js/app.js"></script>
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,13 @@
 {
   "name": "EVERA",
   "short_name": "EVERA",
-  "start_url": "/",
+  "start_url": "./",
   "display": "standalone",
   "background_color": "#0b1020",
   "theme_color": "#0b1020",
   "icons": [
     {
-      "src": "/evera-logo-white.svg",
+      "src": "evera-logo-white.svg",
       "sizes": "any",
       "type": "image/svg+xml"
     }

--- a/pages/b2b.html
+++ b/pages/b2b.html
@@ -4,25 +4,25 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>EVERA для бизнеса — корпоративная память и брендовые истории</title>
 <meta name="description" content="Решения EVERA для бизнеса: цифровой голос основателя, база знаний бренда, обучение и наследие руководителей. Узнайте о модулях, внедрении и тарифах.">
-<link rel="icon" href="/Evera/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/Evera/pages/b2b.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/Evera/pages/b2b.html?lang=en">
+<link rel="icon" href="../assets/icons/favicon.svg">
+<link rel="alternate" hreflang="ru" href="./b2b.html?lang=ru">
+<link rel="alternate" hreflang="en" href="./b2b.html?lang=en">
 <link rel="canonical" href="https://evera.world/b2b">
-<link rel="stylesheet" href="/Evera/css/styles.css">
+<link rel="stylesheet" href="../css/styles.css">
 </head>
 <body>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="../assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="../index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="../pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="../pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="../pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="../pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="../pages/book.html" data-i18n="nav.book">Книга Жизни</a>
+      <a class="btn" href="../pages/b2b.html" data-i18n="nav.b2b">B2B</a>
+      <a class="btn" href="../pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
@@ -218,5 +218,5 @@
   </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
-<script src="/Evera/js/app.js"></script>
+<script src="../js/app.js"></script>
 </body></html>

--- a/pages/book.html
+++ b/pages/book.html
@@ -4,25 +4,25 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Книга Жизни — издание EVERA</title>
 <meta name="description" content="Книга Жизни EVERA: структурированная биография с голосами, фотографиями и интерактивными QR-ссылками. Узнайте, как мы создаём издание и какие форматы доступны.">
-<link rel="icon" href="/Evera/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/Evera/pages/book.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/Evera/pages/book.html?lang=en">
+<link rel="icon" href="../assets/icons/favicon.svg">
+<link rel="alternate" hreflang="ru" href="./book.html?lang=ru">
+<link rel="alternate" hreflang="en" href="./book.html?lang=en">
 <link rel="canonical" href="https://evera.world/book">
-<link rel="stylesheet" href="/Evera/css/styles.css">
+<link rel="stylesheet" href="../css/styles.css">
 </head>
 <body>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="../assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="../index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="../pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="../pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="../pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="../pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="../pages/book.html" data-i18n="nav.book">Книга Жизни</a>
+      <a class="btn" href="../pages/b2b.html" data-i18n="nav.b2b">B2B</a>
+      <a class="btn" href="../pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
@@ -172,5 +172,5 @@
   </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
-<script src="/Evera/js/app.js"></script>
+<script src="../js/app.js"></script>
 </body></html>

--- a/pages/cases.html
+++ b/pages/cases.html
@@ -4,25 +4,25 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Кейсы EVERA — цифровые биографии для семей, музеев и бизнеса</title>
 <meta name="description" content="Реализованные кейсы EVERA: семейные архивы, музеи, корпоративные лидеры. Узнайте, какие задачи решает цифровая биография и как выглядит результат на русском и английском языках.">
-<link rel="icon" href="/Evera/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/Evera/pages/cases.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/Evera/pages/cases.html?lang=en">
+<link rel="icon" href="../assets/icons/favicon.svg">
+<link rel="alternate" hreflang="ru" href="./cases.html?lang=ru">
+<link rel="alternate" hreflang="en" href="./cases.html?lang=en">
 <link rel="canonical" href="https://evera.world/cases">
-<link rel="stylesheet" href="/Evera/css/styles.css">
+<link rel="stylesheet" href="../css/styles.css">
 </head>
 <body>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="../assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="../index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="../pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="../pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="../pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="../pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="../pages/book.html" data-i18n="nav.book">Книга Жизни</a>
+      <a class="btn" href="../pages/b2b.html" data-i18n="nav.b2b">B2B</a>
+      <a class="btn" href="../pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
@@ -166,5 +166,5 @@
   </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
-<script src="/Evera/js/app.js"></script>
+<script src="../js/app.js"></script>
 </body></html>

--- a/pages/eternals.html
+++ b/pages/eternals.html
@@ -4,25 +4,25 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Библиотека «Вечных» — публичные цифровые портреты EVERA</title>
 <meta name="description" content="Библиотека «Вечных» — открытая коллекция цифровых портретов исторических фигур, меценатов и педагогов. Узнайте о миссии, критериях отбора и способах участия.">
-<link rel="icon" href="/Evera/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/Evera/pages/eternals.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/Evera/pages/eternals.html?lang=en">
+<link rel="icon" href="../assets/icons/favicon.svg">
+<link rel="alternate" hreflang="ru" href="./eternals.html?lang=ru">
+<link rel="alternate" hreflang="en" href="./eternals.html?lang=en">
 <link rel="canonical" href="https://evera.world/eternals">
-<link rel="stylesheet" href="/Evera/css/styles.css">
+<link rel="stylesheet" href="../css/styles.css">
 </head>
 <body>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="../assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="../index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="../pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="../pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="../pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="../pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="../pages/book.html" data-i18n="nav.book">Книга Жизни</a>
+      <a class="btn" href="../pages/b2b.html" data-i18n="nav.b2b">B2B</a>
+      <a class="btn" href="../pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
@@ -210,5 +210,5 @@
   </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
-<script src="/Evera/js/app.js"></script>
+<script src="../js/app.js"></script>
 </body></html>

--- a/pages/methodology.html
+++ b/pages/methodology.html
@@ -4,25 +4,25 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Методология EVERA — цифровая биография и диалог</title>
 <meta name="description" content="Методология EVERA: интервью 150+ вопросов, аналитика голоса и эмоций, редакторская валидация и диалоговый ИИ. Узнайте, как создаётся цифровая биография на русском и английском языках.">
-<link rel="icon" href="/Evera/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/Evera/pages/methodology.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/Evera/pages/methodology.html?lang=en">
+<link rel="icon" href="../assets/icons/favicon.svg">
+<link rel="alternate" hreflang="ru" href="./methodology.html?lang=ru">
+<link rel="alternate" hreflang="en" href="./methodology.html?lang=en">
 <link rel="canonical" href="https://evera.world/methodology">
-<link rel="stylesheet" href="/Evera/css/styles.css">
+<link rel="stylesheet" href="../css/styles.css">
 </head>
 <body>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="../assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="../index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="../pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="../pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="../pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="../pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="../pages/book.html" data-i18n="nav.book">Книга Жизни</a>
+      <a class="btn" href="../pages/b2b.html" data-i18n="nav.b2b">B2B</a>
+      <a class="btn" href="../pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
@@ -216,5 +216,5 @@
   </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
-<script src="/Evera/js/app.js"></script>
+<script src="../js/app.js"></script>
 </body></html>

--- a/pages/roadmap.html
+++ b/pages/roadmap.html
@@ -4,25 +4,25 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Дорожная карта EVERA — развитие продукта и исследований</title>
 <meta name="description" content="Планы развития EVERA: новые релизы, исследовательские треки, международные партнёрства. Ознакомьтесь с дорожной картой на русском и английском языках.">
-<link rel="icon" href="/Evera/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/Evera/pages/roadmap.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/Evera/pages/roadmap.html?lang=en">
+<link rel="icon" href="../assets/icons/favicon.svg">
+<link rel="alternate" hreflang="ru" href="./roadmap.html?lang=ru">
+<link rel="alternate" hreflang="en" href="./roadmap.html?lang=en">
 <link rel="canonical" href="https://evera.world/roadmap">
-<link rel="stylesheet" href="/Evera/css/styles.css">
+<link rel="stylesheet" href="../css/styles.css">
 </head>
 <body>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="../assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="../index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="../pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="../pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="../pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="../pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="../pages/book.html" data-i18n="nav.book">Книга Жизни</a>
+      <a class="btn" href="../pages/b2b.html" data-i18n="nav.b2b">B2B</a>
+      <a class="btn" href="../pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
@@ -144,5 +144,5 @@
   </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
-<script src="/Evera/js/app.js"></script>
+<script src="../js/app.js"></script>
 </body></html>

--- a/pages/team.html
+++ b/pages/team.html
@@ -4,25 +4,25 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Команда EVERA — кураторы памяти, редакторы, инженеры</title>
 <meta name="description" content="Познакомьтесь с командой EVERA: кураторы памяти, редакторы, инженеры ИИ и экспертный совет. Узнайте, как мы бережно создаём цифровые портреты и Книги Жизни.">
-<link rel="icon" href="/Evera/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/Evera/pages/team.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/Evera/pages/team.html?lang=en">
+<link rel="icon" href="../assets/icons/favicon.svg">
+<link rel="alternate" hreflang="ru" href="./team.html?lang=ru">
+<link rel="alternate" hreflang="en" href="./team.html?lang=en">
 <link rel="canonical" href="https://evera.world/team">
-<link rel="stylesheet" href="/Evera/css/styles.css">
+<link rel="stylesheet" href="../css/styles.css">
 </head>
 <body>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="../assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="../index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="../pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="../pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="../pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="../pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="../pages/book.html" data-i18n="nav.book">Книга Жизни</a>
+      <a class="btn" href="../pages/b2b.html" data-i18n="nav.b2b">B2B</a>
+      <a class="btn" href="../pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
@@ -206,5 +206,5 @@
   </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
-<script src="/Evera/js/app.js"></script>
+<script src="../js/app.js"></script>
 </body></html>


### PR DESCRIPTION
## Summary
- convert all HTML pages to load CSS, JS, icons, and internal links via relative paths so they work from a GitHub Pages subpath
- update the web app manifest to use relative URLs for the start page and icon

## Testing
- python3 -m http.server 8000
- curl -s http://127.0.0.1:8000/pages/b2b.html | head -n 5

------
https://chatgpt.com/codex/tasks/task_e_68de52245ef8832fbcb18ba32836ff0c