### PR TITLE
Improve landing readability and navigation

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,14 +1,14 @@
 :root{
-  --bg-0:#01030b;
-  --bg-1:#050b1d;
-  --bg-2:#0a1530;
-  --ink:#f3f7ff;
-  --ink-soft:rgba(205,217,243,.78);
+  --bg-0:#00020a;
+  --bg-1:#040a1b;
+  --bg-2:#08152f;
+  --ink:#f5f8ff;
+  --ink-soft:rgba(208,220,244,.82);
   --acc-1:#8ad8ff;
   --acc-2:#7de6c8;
-  --glass:rgba(17,26,48,.72);
-  --glass-strong:rgba(20,32,58,.82);
-  --glass-brd:rgba(138,216,255,.24);
+  --glass:rgba(10,18,36,.82);
+  --glass-strong:rgba(8,16,32,.9);
+  --glass-brd:rgba(138,216,255,.28);
   --radius:18px;
   --shadow:0 28px 60px rgba(4,12,32,.55);
   --ease:cubic-bezier(.22,.61,.36,1);
@@ -113,7 +113,7 @@ main{display:block;overflow-x:hidden}
   margin:0 auto;
   padding:48px 28px;
   border-radius:var(--radius);
-  background:var(--glass);
+  background:var(--glass-strong);
   border:1px solid var(--glass-brd);
   -webkit-backdrop-filter:saturate(160%) blur(18px);
   backdrop-filter:saturate(160%) blur(18px);
@@ -127,6 +127,7 @@ main{display:block;overflow-x:hidden}
   line-height:1.15;
   margin-bottom:12px;
 }
+.hero h1 br{display:block;}
 .hero .lead{
   font-size:18px;
   color:var(--muted);
@@ -191,6 +192,29 @@ main{display:block;overflow-x:hidden}
   max-width:780px;
   color:var(--muted);
   margin-bottom:16px;
+}
+.section-cta{
+  margin-top:28px;
+}
+.more-link{
+  display:inline-flex;
+  align-items:center;
+  gap:10px;
+  color:var(--accent);
+  font-weight:600;
+  text-decoration:none;
+  letter-spacing:.02em;
+  position:relative;
+}
+.more-link::after{
+  content:"→";
+  transition:transform .3s var(--ease);
+}
+.more-link:hover{
+  color:var(--ink);
+}
+.more-link:hover::after{
+  transform:translateX(4px);
 }
 .section .lead{font-size:19px;color:var(--text);margin-bottom:22px;}
 .section ul{
@@ -593,27 +617,6 @@ dialog select:focus-visible{
   margin-top:18px;
 }
 
-/* Footer */
-.footer{
-  border-top:1px solid var(--glass-brd);
-  background:linear-gradient(to top, rgba(0,0,0,.25), rgba(0,0,0,0));
-  padding:40px 0 20px;
-  color:var(--muted);
-}
-.footer-grid{
-  display:flex;
-  justify-content:space-between;
-  gap:40px;
-  flex-wrap:wrap;
-  margin-bottom:20px;
-}
-.footer .copy{
-  text-align:center;
-  font-size:14px;
-  border-top:1px solid var(--glass-brd);
-  padding-top:10px;
-}
-
 /* Responsive adjustments */
 @media (max-width:900px){
   .hero h1{font-size:36px;}
@@ -647,11 +650,25 @@ dialog select:focus-visible{
 .menu-toggle{
   display:none;
   background:transparent;
-  border:none;
+  border:1px solid transparent;
   font-size:28px;
   color:var(--text);
   margin-left:auto;
   cursor:pointer;
+  padding:6px 10px;
+  border-radius:12px;
+  transition:background .3s var(--ease), border-color .3s var(--ease), color .3s var(--ease);
+  position:relative;
+  z-index:5;
+}
+.menu-toggle:hover{
+  background:rgba(138,216,255,.12);
+  border-color:rgba(138,216,255,.3);
+}
+.menu-toggle:focus-visible{
+  outline:none;
+  border-color:rgba(138,216,255,.6);
+  box-shadow:0 0 0 2px rgba(138,216,255,.35);
 }
 
 .nav .links{
@@ -678,7 +695,51 @@ dialog select:focus-visible{
     -webkit-backdrop-filter:saturate(160%) blur(16px);
     backdrop-filter:saturate(160%) blur(16px);
     box-shadow:var(--shadow);
+    z-index:4;
   }
   .nav.open .links{display:flex;}
   .nav .links a{padding:10px 0;text-align:right;width:100%;}
+}
+
+.footer{
+  padding:64px 0 32px;
+  background:linear-gradient(to bottom, rgba(4,10,27,.9), rgba(4,10,27,.96));
+  border-top:1px solid rgba(138,216,255,.2);
+}
+.footer-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(200px,1fr));
+  gap:32px;
+  margin-bottom:32px;
+}
+.footer .logo img{height:28px;}
+.footer-brand .small{margin-top:12px;}
+.footer-col h3{
+  font-size:16px;
+  text-transform:uppercase;
+  letter-spacing:.12em;
+  margin-bottom:14px;
+  color:var(--ink);
+}
+.footer-col ul{list-style:none;padding:0;margin:0;display:grid;gap:10px;}
+.footer-col a{
+  color:var(--muted);
+  text-decoration:none;
+  transition:color .3s var(--ease);
+}
+.footer-col a:hover{color:var(--ink);}
+.footer .copy{
+  text-align:center;
+  font-size:14px;
+  border-top:1px solid rgba(138,216,255,.18);
+  padding-top:12px;
+  color:var(--muted);
+}
+
+@media (max-width:600px){
+  .footer{
+    text-align:left;
+  }
+  .footer-col h3{text-align:left;}
+  .hero h1{font-size:30px;}
 }

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
         <img src="evera-logo-white.svg" alt="EVERA logo">
       </a>
       <!-- Кнопка меню для мобильной версии -->
-      <button id="menuToggle" class="menu-toggle" aria-label="Меню">☰</button>
+      <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню">☰</button>
       <!-- Ссылки навигации: скрываются на мобильной версии и открываются по кнопке -->
       <div class="links">
         <a href="#mission" class="active">Главная</a>
@@ -61,7 +61,7 @@
     <section id="mission" class="hero">
       <div class="container">
         <div class="overlay">
-          <h1>EVERA | Оцифровка памяти | Портал в вечность</h1>
+          <h1>EVERA<br>Оцифровка памяти<br>Портал в вечность</h1>
           <p class="lead">Мы сохраняем голоса, истории и ценности, чтобы потомки могли вести диалоги через годы. Интервью 150+ вопросов, аналитика речи и «Книга Жизни» превращают память в живой диалог.</p>
           <div class="cta">
             <a class="btn" href="#process">Узнать, как это работает</a>
@@ -130,6 +130,9 @@
             </div>
           </div>
         </div>
+        <div class="section-cta">
+          <a class="more-link" href="/Evera/pages/methodology.html">Подробнее о методологии</a>
+        </div>
       </div>
     </section>
 
@@ -155,6 +158,9 @@
           таймлайны, QR‑коды к аудио и видео‑фрагментам. Версия может быть печатной, интерактивным PDF или
           веб‑изданием с расширенным поиском и оглавлением. Редакция аккуратно собирает голосовой портрет:
           характерные слова и интонации становятся навигацией по смыслу.</p>
+        <div class="section-cta">
+          <a class="more-link" href="/Evera/pages/book.html">Подробнее о Книге Жизни</a>
+        </div>
       </div>
     </section>
 
@@ -168,6 +174,9 @@
           стиль, подтверждены источники, указаны ограничения реконструкции. Преподаватели используют библиотеку
           как интерактивный учебник; семьи и фонды - как мемориальный ИИ‑архив: экспозиции, аудиогиды, тематические
           встречи.</p>
+        <div class="section-cta">
+          <a class="more-link" href="/Evera/pages/eternals.html">Открыть Библиотеку Вечных</a>
+        </div>
       </div>
     </section>
 
@@ -209,8 +218,11 @@
           <p>Смотрите тарифы EVERA или получите индивидуальный расчёт - команда ответит на почту и в Telegram.</p>
           <div class="cta-actions">
             <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20-%20Запрос%20расчёта">Запросить расчёт</a>
-            <a class="btn" href="/Evera/pages/pricing.html">Тарифы EVERA</a>
+            <a class="btn" href="/Evera/pages/pricing.html">Все тарифы</a>
             <a class="btn ghost" href="https://t.me/Solo013" target="_blank" rel="noopener">Telegram</a>
+          </div>
+          <div class="section-cta">
+            <a class="more-link" href="/Evera/pages/b2b.html">Подробнее о решениях для бизнеса</a>
           </div>
         </div>
       </div>
@@ -326,14 +338,40 @@
   <footer class="footer">
     <div class="container">
       <div class="footer-grid">
-        <div>
-          <a class="logo" href="#" aria-label="EVERA"><img src="evera-logo-white.svg" alt="EVERA"></a>
-          <p class="small">EVERA | цифровое бессмертие и живой диалог.</p>
+        <div class="footer-brand">
+          <a class="logo" href="#mission" aria-label="EVERA"><img src="evera-logo-white.svg" alt="EVERA"></a>
+          <p class="small">EVERA — цифровое бессмертие и живой диалог между поколениями.</p>
+          <p class="small">Контакты: <a href="mailto:hello@evera.world">hello@evera.world</a><br><a href="https://t.me/Solo013" target="_blank" rel="noopener">t.me/Solo013</a></p>
         </div>
-        <div>
-          <p class="small">Контакты: <a href="https://t.me/Solo013" target="_blank" rel="noopener">t.me/Solo013</a></p>
-          <p class="small"><a href="/Evera/pages/pricing.html">Тарифы</a> · <a href="/Evera/en/pages/pricing.html">Pricing</a></p>
-          <p class="small"><a href="/sitemap.xml">sitemap</a> · <a href="/robots.txt">robots</a></p>
+        <div class="footer-col">
+          <h3>Навигация</h3>
+          <ul>
+            <li><a href="#what">Что такое EVERA</a></li>
+            <li><a href="#process">Методология</a></li>
+            <li><a href="#book">Книга Жизни</a></li>
+            <li><a href="#eternals">Библиотека Вечных</a></li>
+            <li><a href="#b2b">Корпоративные решения</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3>Страницы</h3>
+          <ul>
+            <li><a href="/Evera/pages/methodology.html">Методология EVERA</a></li>
+            <li><a href="/Evera/pages/book.html">Книга Жизни</a></li>
+            <li><a href="/Evera/pages/eternals.html">Библиотека Вечных</a></li>
+            <li><a href="/Evera/pages/b2b.html">Решения для бизнеса</a></li>
+            <li><a href="/Evera/pages/pricing.html">Все тарифы</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3>Документы</h3>
+          <ul>
+            <li><a href="/sitemap.xml">Карта сайта</a></li>
+            <li><a href="/robots.txt">robots.txt</a></li>
+            <li><a href="/Evera/pages/team.html">Команда</a></li>
+            <li><a href="/Evera/pages/roadmap.html">Дорожная карта</a></li>
+            <li><a href="/Evera/pages/cases.html">Кейсы</a></li>
+          </ul>
         </div>
       </div>
       <div class="copy">© 2025 EVERA · No ads · No trackers</div>

--- a/js/app.js
+++ b/js/app.js
@@ -182,7 +182,7 @@
   function drawFrame(timeMs) {
     if (!imageData) return;
     const data = imageData.data;
-    const time = (timeMs || 0) * 0.00008;
+    const time = (timeMs || 0) * 0.000096;
     let offset = 0;
     for (let y = 0; y < sampleH; y++) {
       const ny = y / sampleH;
@@ -277,7 +277,7 @@
 
   let w, h, stars = [];
   const STAR_COUNT = 760;
-  const SPEED = 0.0008;
+  const SPEED = 0.00096;
   let animId;
   let lastTime = null;
 


### PR DESCRIPTION
## Summary
- darken the landing background glass treatment and reformat the hero heading into three lines for better contrast
- add contextual “Подробнее” links, refresh the footer, and adjust CTA labels to surface deep pages
- fix the mobile hamburger toggle hit area and speed up the canvas animations by 20%

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68de8741c840832f84d8ab1d797a0b83