### PR TITLE
Adjust hero overlay transparency

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -7,7 +7,7 @@
   --acc-1:#8ad8ff;
   --acc-2:#7de6c8;
   --glass:rgba(10,18,36,.82);
-  --glass-strong:rgba(8,16,32,.9);
+  --glass-strong:rgba(8,16,32,.6);
   --glass-brd:rgba(138,216,255,.28);
   --radius:18px;
   --shadow:0 28px 60px rgba(4,12,32,.55);
@@ -120,6 +120,10 @@ main{display:block;overflow-x:hidden}
   box-shadow:var(--shadow);
   text-align:center;
   transition:transform .6s var(--ease), box-shadow .6s var(--ease);
+}
+.hero h1,
+.hero .lead{
+  text-shadow:0 8px 28px rgba(2,8,20,.55);
 }
 .hero .overlay:hover{transform:translateY(-6px);box-shadow:0 32px 72px rgba(6,18,48,.65);}
 .hero h1{


### PR DESCRIPTION
## Summary
- reduce the hero glass overlay opacity so the starry background remains visible
- strengthen the hero heading and lead text contrast with a deeper shadow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68debfe5db54832f930048fa1ce7e655