### PR TITLE
Add hero stat grid to highlight key metrics

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -133,6 +133,17 @@ main{display:block;overflow-x:hidden}
   color:var(--muted);
   margin-bottom:24px;
 }
+.hero .stat-grid{
+  margin-top:32px;
+  justify-items:stretch;
+}
+.hero .stat{
+  background:rgba(255,255,255,.06);
+  border:1px solid rgba(255,255,255,.08);
+  border-radius:18px;
+  padding:20px 22px;
+}
+.hero .stat b{color:var(--text);}
 .cta{
   display:flex;
   gap:14px;

--- a/index.html
+++ b/index.html
@@ -67,6 +67,16 @@
             <a class="btn" href="#process">Узнать, как это работает</a>
             <a class="btn ghost" href="https://t.me/sololabschannel" target="_blank" rel="noopener">Telegram-канал</a>
           </div>
+          <div class="stat-grid">
+            <div class="stat"><b>150+</b>вопросов в глубинном интервью</div>
+            <div class="stat"><b>12</b>тематических модулей анализа</div>
+            <div class="stat"><b>48</b>часов живого голоса и видео</div>
+            <div class="stat"><b>24/7</b>доступ к цифровому портрету</div>
+            <div class="stat"><b>100%</b>контроль приватности и доступов</div>
+            <div class="stat"><b>20+</b>эмоциональных и лексических метрик</div>
+            <div class="stat"><b>3</b>формата издания «Книги Жизни»</div>
+            <div class="stat"><b>1</b>диалоговый ИИ, звучащий как оригинал</div>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add the stat grid to the hero section with eight key EVERA metrics
- refine hero-specific stat styles for spacing and glassmorphism consistency

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68debfe62a44832f917da30863bb2dc0