### PR TITLE
Replace section CTA links with buttons

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -194,27 +194,14 @@ main{display:block;overflow-x:hidden}
   margin-bottom:16px;
 }
 .section-cta{
-  margin-top:28px;
+  margin-top:32px;
+  display:flex;
+  justify-content:flex-start;
+  flex-wrap:wrap;
+  gap:12px;
 }
-.more-link{
-  display:inline-flex;
-  align-items:center;
-  gap:10px;
-  color:var(--accent);
-  font-weight:600;
-  text-decoration:none;
-  letter-spacing:.02em;
-  position:relative;
-}
-.more-link::after{
-  content:"→";
-  transition:transform .3s var(--ease);
-}
-.more-link:hover{
-  color:var(--ink);
-}
-.more-link:hover::after{
-  transform:translateX(4px);
+.section-cta .btn{
+  margin:0;
 }
 .section .lead{font-size:19px;color:var(--text);margin-bottom:22px;}
 .section ul{
@@ -742,4 +729,5 @@ dialog select:focus-visible{
   }
   .footer-col h3{text-align:left;}
   .hero h1{font-size:30px;}
+  .section-cta{justify-content:center;}
 }

--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
           </div>
         </div>
         <div class="section-cta">
-          <a class="more-link" href="/Evera/pages/methodology.html">Подробнее о методологии</a>
+          <a class="btn ghost" href="/Evera/pages/methodology.html">Подробнее о методологии</a>
         </div>
       </div>
     </section>
@@ -159,7 +159,7 @@
           веб‑изданием с расширенным поиском и оглавлением. Редакция аккуратно собирает голосовой портрет:
           характерные слова и интонации становятся навигацией по смыслу.</p>
         <div class="section-cta">
-          <a class="more-link" href="/Evera/pages/book.html">Подробнее о Книге Жизни</a>
+          <a class="btn ghost" href="/Evera/pages/book.html">Подробнее о Книге Жизни</a>
         </div>
       </div>
     </section>
@@ -175,7 +175,7 @@
           как интерактивный учебник; семьи и фонды - как мемориальный ИИ‑архив: экспозиции, аудиогиды, тематические
           встречи.</p>
         <div class="section-cta">
-          <a class="more-link" href="/Evera/pages/eternals.html">Открыть Библиотеку Вечных</a>
+          <a class="btn ghost" href="/Evera/pages/eternals.html">Открыть Библиотеку Вечных</a>
         </div>
       </div>
     </section>
@@ -222,7 +222,7 @@
             <a class="btn ghost" href="https://t.me/Solo013" target="_blank" rel="noopener">Telegram</a>
           </div>
           <div class="section-cta">
-            <a class="more-link" href="/Evera/pages/b2b.html">Подробнее о решениях для бизнеса</a>
+            <a class="btn ghost" href="/Evera/pages/b2b.html">Подробнее о решениях для бизнеса</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace legacy `.more-link` anchors with `.btn` button styling in home page sections
- refresh `.section-cta` spacing and alignment so the new buttons keep the vertical rhythm across viewports
- remove the redundant `.more-link` styles from the stylesheet

## Testing
- not run (static site update)


------
https://chatgpt.com/codex/tasks/task_e_68debfe70d58832fa71ddb2c267f1263