### PR TITLE
Improve mobile navigation and readability

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -199,6 +199,33 @@ main{display:block;overflow-x:hidden}
   padding:64px 0;
 }
 
+.section > .container{
+  position:relative;
+  padding:48px clamp(18px, 6vw, 42px);
+  border-radius:calc(var(--radius) + 4px);
+  background:linear-gradient(160deg, rgba(12,24,54,.88), rgba(6,14,32,.78));
+  border:1px solid var(--glass-brd);
+  -webkit-backdrop-filter:saturate(170%) blur(18px);
+  backdrop-filter:saturate(170%) blur(18px);
+  box-shadow:0 28px 60px rgba(4,12,32,.55);
+  overflow:hidden;
+}
+
+.section > .container::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:radial-gradient(600px 320px at 10% 0%, rgba(138,216,255,.16), transparent 70%),
+    radial-gradient(520px 320px at 90% 100%, rgba(125,230,200,.12), transparent 68%);
+  opacity:.85;
+  pointer-events:none;
+}
+
+.section > .container > *{
+  position:relative;
+  z-index:1;
+}
+
 .section h2{
   font-size:32px;
   margin-bottom:12px;
@@ -624,6 +651,7 @@ dialog select:focus-visible{
   .hero h1{font-size:36px;}
   .section h2{font-size:28px;}
   .nav{overflow-x:auto;gap:12px;}
+  .section > .container{padding:40px clamp(16px, 6vw, 30px);}
 }
 
 /* Kickers & section metadata */
@@ -667,6 +695,11 @@ dialog select:focus-visible{
   background:rgba(138,216,255,.12);
   border-color:rgba(138,216,255,.3);
 }
+.menu-toggle.is-open{
+  background:rgba(138,216,255,.18);
+  border-color:rgba(138,216,255,.45);
+  color:var(--ink);
+}
 .menu-toggle:focus-visible{
   outline:none;
   border-color:rgba(138,216,255,.6);
@@ -675,7 +708,22 @@ dialog select:focus-visible{
 
 .nav .links{
   display:flex;
+  gap:28px;
+  align-items:center;
+}
+
+.nav .links .menu-group{
+  display:flex;
+  align-items:center;
   gap:18px;
+}
+
+.nav .links .menu-title{
+  display:none;
+  font-size:12px;
+  letter-spacing:.14em;
+  text-transform:uppercase;
+  color:var(--muted);
 }
 
 @media (max-width:900px){
@@ -687,12 +735,13 @@ dialog select:focus-visible{
     right:0;
     top:100%;
     flex-direction:column;
-    align-items:flex-end;
-    width:100%;
+    align-items:stretch;
+    gap:22px;
+    width:min(420px, 100%);
     background:var(--glass-strong);
     border:1px solid var(--glass-brd);
     border-top:none;
-    padding:12px 20px 20px;
+    padding:18px 22px 24px;
     border-radius:0 0 var(--radius) var(--radius);
     -webkit-backdrop-filter:saturate(160%) blur(16px);
     backdrop-filter:saturate(160%) blur(16px);
@@ -700,7 +749,18 @@ dialog select:focus-visible{
     z-index:4;
   }
   .nav.open .links{display:flex;}
-  .nav .links a{padding:10px 0;text-align:right;width:100%;}
+  .nav .links .menu-group{
+    flex-direction:column;
+    align-items:flex-start;
+    gap:10px;
+  }
+  .nav .links .menu-title{display:block;font-size:13px;color:var(--ink);opacity:.82;}
+  .nav .links a{
+    padding:10px 0;
+    width:100%;
+    text-align:left;
+    border-radius:10px;
+  }
 }
 
 .footer{
@@ -745,4 +805,5 @@ dialog select:focus-visible{
   .footer-col h3{text-align:left;}
   .hero h1{font-size:30px;}
   .section-cta{justify-content:center;}
+  .section > .container{padding:32px 18px;border-radius:var(--radius);}
 }

--- a/index.html
+++ b/index.html
@@ -38,20 +38,33 @@
         <img src="evera-logo-white.svg" alt="EVERA logo">
       </a>
       <!-- Кнопка меню для мобильной версии -->
-      <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню">☰</button>
+      <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню" aria-expanded="false" aria-controls="primaryNav">☰</button>
       <!-- Ссылки навигации: скрываются на мобильной версии и открываются по кнопке -->
-      <div class="links">
-        <a href="#mission" class="active">Главная</a>
-        <a href="#what">Что такое</a>
-        <a href="#process">Процесс</a>
-        <a href="#ai">ИИ</a>
-        <a href="#book">Книга Жизни</a>
-        <a href="#eternals">Вечные</a>
-        <a href="#audience">Для кого</a>
-        <a href="#b2b">Бизнес</a>
-        <a href="/Evera/pages/pricing.html">Тарифы</a>
-        <a href="#ethics">Этика</a>
-        <a href="#faq">FAQ</a>
+      <div class="links" id="primaryNav">
+        <div class="menu-group" aria-label="Навигация по разделам страницы">
+          <span class="menu-title">Разделы</span>
+          <a href="#mission" class="active">Главная</a>
+          <a href="#what">Что такое</a>
+          <a href="#process">Процесс</a>
+          <a href="#ai">ИИ</a>
+          <a href="#book">Книга Жизни</a>
+          <a href="#eternals">Вечные</a>
+          <a href="#audience">Для кого</a>
+          <a href="#b2b">Бизнес</a>
+          <a href="#ethics">Этика</a>
+          <a href="#faq">FAQ</a>
+        </div>
+        <div class="menu-group" aria-label="Отдельные страницы сайта">
+          <span class="menu-title">Страницы</span>
+          <a href="/Evera/pages/pricing.html">Тарифы</a>
+          <a href="/Evera/pages/methodology.html">Методология</a>
+          <a href="/Evera/pages/book.html">Издание «Книга Жизни»</a>
+          <a href="/Evera/pages/eternals.html">Библиотека «Вечных»</a>
+          <a href="/Evera/pages/b2b.html">Корпоративные решения</a>
+          <a href="/Evera/pages/cases.html">Кейсы</a>
+          <a href="/Evera/pages/team.html">Команда</a>
+          <a href="/Evera/pages/roadmap.html">Роадмап</a>
+        </div>
       </div>
     </div>
   </header>
@@ -69,13 +82,11 @@
           </div>
           <div class="stat-grid">
             <div class="stat"><b>150+</b>вопросов в глубинном интервью</div>
-            <div class="stat"><b>12</b>тематических модулей анализа</div>
-            <div class="stat"><b>48</b>часов живого голоса и видео</div>
+            <div class="stat"><b>1 млн+</b>слов — минимальный объём данных</div>
             <div class="stat"><b>24/7</b>доступ к цифровому портрету</div>
             <div class="stat"><b>100%</b>контроль приватности и доступов</div>
-            <div class="stat"><b>20+</b>эмоциональных и лексических метрик</div>
-            <div class="stat"><b>3</b>формата издания «Книги Жизни»</div>
-            <div class="stat"><b>1</b>диалоговый ИИ, звучащий как оригинал</div>
+            <div class="stat"><b>20+</b>эмоциональных и метрических метрик</div>
+            <div class="stat">Издание «Книга Жизни» на основе биографии</div>
           </div>
         </div>
       </div>

--- a/js/app.js
+++ b/js/app.js
@@ -498,7 +498,33 @@
   const nav = document.querySelector('.nav');
   const toggle = document.getElementById('menuToggle');
   if (!nav || !toggle) return;
+  const links = nav.querySelectorAll('.links a');
+  const setExpanded = (state) => {
+    nav.classList.toggle('open', state);
+    toggle.setAttribute('aria-expanded', state ? 'true' : 'false');
+    toggle.classList.toggle('is-open', state);
+    toggle.textContent = state ? '✕' : '☰';
+  };
+
+  setExpanded(false);
+
   toggle.addEventListener('click', () => {
-    nav.classList.toggle('open');
+    const willOpen = !nav.classList.contains('open');
+    setExpanded(willOpen);
+  });
+
+  links.forEach((link) => {
+    link.addEventListener('click', () => {
+      if (nav.classList.contains('open')) {
+        setExpanded(false);
+      }
+    });
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && nav.classList.contains('open')) {
+      setExpanded(false);
+      toggle.focus();
+    }
   });
 })();


### PR DESCRIPTION
## Summary
- redesign the mobile navigation to show grouped section links and standalone pages with improved accessibility
- add translucent glass panels to content sections so text remains legible against the starry background
- refresh the hero metrics to the six key selling points requested by the brief

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68dec30abb6c832f88438d28afaac7fb