### PR TITLE
Implement drawer navigation and update star tunnel animation

### DIFF
--- a/assets/icons/analysis.svg
+++ b/assets/icons/analysis.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#7CE3FF" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="4" y="4" width="12" height="12" rx="2"/>
+  <path d="M7 13l2.8-3.2L12 12l3.2-4"/>
+  <circle cx="16.5" cy="16.5" r="3.5"/>
+  <path d="M19 19l2.5 2.5"/>
+</svg>

--- a/assets/icons/dialog.svg
+++ b/assets/icons/dialog.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#7CE3FF" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M5 5h14v8H9l-4 4V5z"/>
+  <path d="M10 15h5l4 4v-7"/>
+</svg>

--- a/assets/icons/interview.svg
+++ b/assets/icons/interview.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#7CE3FF" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="9" y="3" width="6" height="11" rx="3"/>
+  <path d="M12 14v4"/>
+  <path d="M8 11a4 4 0 0 0 8 0"/>
+  <path d="M7 19h10"/>
+  <path d="M5.5 6.5l2 2"/>
+  <path d="M18.5 6.5l-2 2"/>
+</svg>

--- a/css/styles.css
+++ b/css/styles.css
@@ -57,7 +57,7 @@ body[data-nebula="home"]::before{
 }
 @keyframes grid-breathe{ from{opacity:.08} to{opacity:.12} }
 
-body.nav-open{overflow:hidden}
+.body--nav-open{overflow:hidden}
 
 a{color:var(--accent);text-decoration:none}
 a:hover{color:#b6f1ff}
@@ -133,7 +133,9 @@ main, header, footer, section{position:relative;z-index:1}
   border-radius:12px;
   cursor:pointer;
   transition:transform .2s ease, border-color .2s ease, background .2s ease;
-  display:none;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
 }
 .menu-toggle:hover{background:rgba(124,227,255,.12);border-color:rgba(124,227,255,.42)}
 .menu-toggle[aria-expanded="true"]{background:rgba(124,227,255,.2);border-color:rgba(124,227,255,.5)}
@@ -150,64 +152,90 @@ main, header, footer, section{position:relative;z-index:1}
 .links a:hover,.links a:focus-visible{color:var(--text)}
 .links a:hover::after,.links a:focus-visible::after,.links a.active::after{transform:scaleX(1)}
 
-@media (max-width:1024px){
-  .links .menu-group{gap:14px}
+@media (min-width:1024px){
+  .header .links .menu-group:nth-child(2){display:none}
 }
-@media (max-width:900px){
-  .links{display:none}
-  .menu-toggle{display:inline-flex}
+@media (max-width:1023px){
+  .header .links{display:none}
 }
 
+/* overlay */
 .nav-overlay{
   position:fixed;
   inset:0;
-  background:rgba(5,9,20,.72);
+  z-index:999;
+  background:rgba(5,9,20,.55);
   backdrop-filter:blur(6px);
   -webkit-backdrop-filter:blur(6px);
-  display:flex;
-  align-items:flex-start;
-  justify-content:center;
   opacity:0;
-  pointer-events:none;
-  transition:opacity .3s ease;
-  z-index:20;
+  transition:opacity .25s ease;
 }
-.nav-overlay.is-visible{opacity:1;pointer-events:auto}
-.nav-overlay__backdrop{position:absolute;inset:0}
-.nav-overlay__panel{
-  position:relative;
-  margin:90px 24px 24px;
-  background:rgba(12,30,51,.9);
-  border:1px solid rgba(124,227,255,.25);
-  border-radius:20px;
-  width:min(640px, calc(100% - 48px));
-  padding:32px clamp(24px, 4vw, 40px);
-  color:var(--text);
-  box-shadow:0 28px 80px rgba(5,14,30,.45);
+#navOverlay{display:none}
+
+/* drawer */
+.nav-drawer{
+  position:fixed;
+  top:0;
+  right:0;
+  height:100dvh;
+  z-index:1000;
+  width:min(480px,50vw);
+  max-width:100%;
+  background:rgba(10,22,48,.92);
+  border-left:1px solid rgba(124,227,255,.18);
+  transform:translateX(100%);
+  transition:transform .3s ease;
   display:flex;
   flex-direction:column;
-  gap:24px;
 }
-.nav-overlay__header{display:flex;align-items:center;justify-content:space-between;gap:12px}
-.nav-overlay__header h2{margin:0;font-size:var(--h2)}
-.nav-overlay__close{
+.nav-drawer__header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  padding:16px 18px;
+  border-bottom:1px solid rgba(124,227,255,.14);
+}
+.nav-drawer__close{
   background:transparent;
-  border:1px solid rgba(124,227,255,.3);
+  border:1px solid rgba(124,227,255,.25);
+  border-radius:12px;
+  padding:8px 10px;
   color:var(--text);
-  border-radius:50%;
-  width:40px;
-  height:40px;
-  font-size:24px;
-  line-height:1;
   cursor:pointer;
-  transition:transform .2s ease, border-color .2s ease;
 }
-.nav-overlay__close:hover{border-color:rgba(124,227,255,.6);transform:rotate(90deg)}
-.nav-overlay__content{display:grid;gap:32px;grid-template-columns:repeat(auto-fit,minmax(200px,1fr))}
-.nav-overlay__title{display:block;font-size:12px;letter-spacing:.2em;text-transform:uppercase;color:var(--muted);margin-bottom:12px}
-.nav-overlay__group ul{list-style:none;margin:0;padding:0;display:grid;gap:10px}
-.nav-overlay__group a{color:var(--text);padding:6px 0;border-radius:8px;transition:color .2s ease, background .2s ease}
-.nav-overlay__group a:hover{background:rgba(124,227,255,.12);color:var(--accent)}
+.nav-drawer__close:where(:hover,:focus-visible){
+  background:rgba(124,227,255,.08);
+  border-color:rgba(124,227,255,.4);
+}
+.nav-drawer__body{
+  padding:12px 18px 24px;
+  overflow:auto;
+  height:100%;
+}
+.drawer-group{margin-bottom:20px}
+.drawer-title{
+  font-size:12px;
+  letter-spacing:.12em;
+  text-transform:uppercase;
+  color:var(--muted);
+  margin:12px 0 8px;
+}
+.nav-drawer a{
+  display:block;
+  padding:10px 6px;
+  border-radius:10px;
+  color:var(--text);
+  border:1px solid transparent;
+}
+.nav-drawer a:where(:hover,:focus-visible){
+  border-color:rgba(124,227,255,.18);
+  background:rgba(12,30,51,.35);
+}
+
+/* open states */
+.body--nav-open .nav-overlay{opacity:1}
+.body--nav-open #navOverlay{display:block}
+.body--nav-open #navDrawer{transform:translateX(0)}
 
 .section{padding:var(--space-section) 0}
 @media (max-width:768px){ .section{padding:var(--space-section-m) 0} }
@@ -266,10 +294,17 @@ h3{font-size:var(--h3); line-height:1.3; margin:0 0 12px}
 .stat b{display:inline-block; margin-right:6px; color:var(--accent)}
 .stat:where(:hover,:focus-within){ transform:translateY(-4px); box-shadow:0 8px 24px rgba(124,227,255,.08) }
 
-.process{display:grid;gap:18px;margin-top:32px}
+.process{display:grid;gap:16px;margin-top:32px}
 @media (min-width:768px){.process{grid-template-columns:repeat(3,minmax(0,1fr))}}
-.step{border:1px solid rgba(124,227,255,.18);border-radius:14px;padding:22px;background:rgba(12,30,51,.25);box-shadow:0 16px 36px rgba(5,14,32,.3)}
+.step{display:flex;gap:12px;padding:16px;border-radius:14px;border:1px solid rgba(124,227,255,.18);background:rgba(12,30,51,.25)}
+.step-icon{flex:0 0 auto;display:grid;place-items:center;width:32px;height:32px;border-radius:10px;background:rgba(124,227,255,.08)}
+.step-icon img{width:24px;height:24px;display:block}
 .step-content{color:var(--muted)}
+@media (min-width:1024px){
+  .step{padding:18px}
+  .step-icon{width:36px;height:36px}
+  .step-icon img{width:28px;height:28px}
+}
 
 .business-list{list-style:none;margin:28px 0 0;padding:0;display:grid;gap:16px}
 .business-list li{background:rgba(12,30,51,.2);border:1px solid rgba(124,227,255,.16);border-radius:12px;padding:16px;color:var(--muted)}
@@ -329,7 +364,6 @@ dialog .modal-actions{display:flex;gap:12px;justify-content:flex-end;margin-top:
   .hero{padding-top:120px}
   .hero .overlay{padding:40px 24px}
   .cta{justify-content:flex-start}
-  .nav-overlay__panel{margin-top:72px}
 }
 
 @media (max-width:600px){

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
 <body data-nebula="home">
   <div class="read-progress" id="readProgress" aria-hidden="true"></div>
   <!-- Туманность с наложением. Располагается под слоем звёзд. -->
-  <canvas id="nebula" aria-hidden="true"></canvas>
+  <canvas id="nebula" data-parallax-speed="0.006" aria-hidden="true"></canvas>
   <!-- Звёздное небо на фоне. Canvas размещён под контентом. -->
   <canvas id="stars" aria-hidden="true"></canvas>
   <div class="parallax-layer parallax-layer--nebula" data-parallax-speed="0.008" aria-hidden="true"></div>
@@ -42,7 +42,7 @@
       <a class="logo" href="#mission" aria-label="EVERA">
         <img src="evera-logo-white.svg" alt="EVERA logo">
       </a>
-      <button id="menuToggle" class="menu-toggle" type="button" aria-label="Открыть меню" aria-expanded="false" aria-controls="navOverlay">☰</button>
+      <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню" aria-expanded="false" aria-controls="navDrawer">☰</button>
       <nav class="links" id="primaryNav" aria-label="Основная навигация">
         <div class="menu-group" aria-label="Навигация по разделам страницы">
           <a href="#mission" class="active">Главная</a>
@@ -56,59 +56,45 @@
           <a href="#ethics">Этика</a>
           <a href="#faq">FAQ</a>
         </div>
-        <div class="menu-group" aria-label="Отдельные страницы сайта">
-          <a href="/Evera/pages/pricing.html">Тарифы</a>
-          <a href="/Evera/pages/methodology.html">Методология</a>
-          <a href="/Evera/pages/book.html">Издание «Книга Жизни»</a>
-          <a href="/Evera/pages/eternals.html">Библиотека «Вечных»</a>
-          <a href="/Evera/pages/b2b.html">Корпоративные решения</a>
-          <a href="/Evera/pages/cases.html">Кейсы</a>
-          <a href="/Evera/pages/team.html">Команда</a>
-          <a href="/Evera/pages/roadmap.html">Роадмап</a>
-        </div>
       </nav>
     </div>
   </header>
 
-  <div class="nav-overlay" id="navOverlay" aria-hidden="true">
-    <div class="nav-overlay__backdrop" data-nav-dismiss></div>
-    <div class="nav-overlay__panel" role="dialog" aria-modal="true" aria-labelledby="navOverlayTitle">
-      <div class="nav-overlay__header">
-        <h2 id="navOverlayTitle">Меню</h2>
-        <button type="button" class="nav-overlay__close" id="navClose" aria-label="Закрыть меню">×</button>
-      </div>
-      <div class="nav-overlay__content" data-focus-trap>
-        <nav class="nav-overlay__group" aria-label="Разделы страницы">
-          <span class="nav-overlay__title">Разделы</span>
-          <ul>
-            <li><a href="#mission">Главная</a></li>
-            <li><a href="#what">Что такое</a></li>
-            <li><a href="#process">Процесс</a></li>
-            <li><a href="#ai">ИИ</a></li>
-            <li><a href="#book">Книга Жизни</a></li>
-            <li><a href="#eternals">Вечные</a></li>
-            <li><a href="#audience">Для кого</a></li>
-            <li><a href="#b2b">Бизнес</a></li>
-            <li><a href="#ethics">Этика</a></li>
-            <li><a href="#faq">FAQ</a></li>
-          </ul>
-        </nav>
-        <nav class="nav-overlay__group" aria-label="Страницы проекта">
-          <span class="nav-overlay__title">Страницы</span>
-          <ul>
-            <li><a href="/Evera/pages/pricing.html">Тарифы</a></li>
-            <li><a href="/Evera/pages/methodology.html">Методология</a></li>
-            <li><a href="/Evera/pages/book.html">Издание «Книга Жизни»</a></li>
-            <li><a href="/Evera/pages/eternals.html">Библиотека «Вечных»</a></li>
-            <li><a href="/Evera/pages/b2b.html">Корпоративные решения</a></li>
-            <li><a href="/Evera/pages/cases.html">Кейсы</a></li>
-            <li><a href="/Evera/pages/team.html">Команда</a></li>
-            <li><a href="/Evera/pages/roadmap.html">Роадмап</a></li>
-          </ul>
-        </nav>
-      </div>
+  <div class="nav-overlay" id="navOverlay" hidden></div>
+  <aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
+    <div class="nav-drawer__header">
+      <h2 id="menuTitle">Меню</h2>
+      <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню">✕</button>
     </div>
-  </div>
+
+    <nav class="nav-drawer__body" aria-label="Навигация по сайту">
+      <div class="drawer-group">
+        <div class="drawer-title">Разделы</div>
+        <a href="#mission">Главная</a>
+        <a href="#what">Что такое</a>
+        <a href="#process">Процесс</a>
+        <a href="#ai">ИИ</a>
+        <a href="#book">Книга Жизни</a>
+        <a href="#eternals">Вечные</a>
+        <a href="#audience">Для кого</a>
+        <a href="#b2b">Бизнес</a>
+        <a href="#ethics">Этика</a>
+        <a href="#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group">
+        <div class="drawer-title">Страницы</div>
+        <a href="/Evera/pages/pricing.html">Тарифы</a>
+        <a href="/Evera/pages/methodology.html">Методология</a>
+        <a href="/Evera/pages/book.html">Издание «Книга Жизни»</a>
+        <a href="/Evera/pages/eternals.html">Библиотека «Вечных»</a>
+        <a href="/Evera/pages/b2b.html">Корпоративные решения</a>
+        <a href="/Evera/pages/cases.html">Кейсы</a>
+        <a href="/Evera/pages/team.html">Команда</a>
+        <a href="/Evera/pages/roadmap.html">Роадмап</a>
+      </div>
+    </nav>
+  </aside>
 
   <main>
     <!-- Hero/mission: короткий призыв и основная идея -->
@@ -171,6 +157,9 @@
         <p class="sub">Интервью → Аналитика → Диалог. Бережно, прозрачно, без мистики.</p>
         <div class="process reveal-stagger">
           <div class="step">
+            <div class="step-icon">
+              <img src="/assets/icons/interview.svg" alt="" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Ccircle%20cx%3D%2212%22%20cy%3D%229%22%20r%3D%224%22/%3E%3Cpath%20d%3D%22M8%2015c0%202.209%201.791%204%204%204s4-1.791%204-4%22/%3E%3Cpath%20d%3D%22M5%205l2.5%202.5M19%205l-2.5%202.5%22/%3E%3C/svg%3E';">
+            </div>
             <div class="step-content">
               <b>Интервью: 150+ вопросов</b><br>
               Детство, семья, родословная, обучение, работа, увлечения, этические выборы и философия. Формат
@@ -179,6 +168,9 @@
             </div>
           </div>
           <div class="step">
+            <div class="step-icon">
+              <img src="/assets/icons/analysis.svg" alt="" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22M4%2015l4-4%203%203%205-5%204%204%22/%3E%3Cpath%20d%3D%22M4%204h16v16H4z%22/%3E%3C/svg%3E';">
+            </div>
             <div class="step-content">
               <b>Аналитика: лексика, эмоции, структура</b><br>
               Аудио расшифровывается, сегментируется, очищается. Истории кластеризуются, эпизоды и персонажи
@@ -187,6 +179,9 @@
             </div>
           </div>
           <div class="step">
+            <div class="step-icon">
+              <img src="/assets/icons/dialog.svg" alt="" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22M5%205h14v8H9l-4%204z%22/%3E%3Cpath%20d%3D%22M9%2015v4l4-4h6v4l-4%204v-4H9z%22/%3E%3C/svg%3E';">
+            </div>
             <div class="step-content">
               <b>Диалоговый слой: голос, стиль, доступ</b><br>
               На основе когнитивной модели формируется виртуальный собеседник: он отвечает в стиле и темпе

--- a/js/app.js
+++ b/js/app.js
@@ -1,46 +1,61 @@
+
 (() => {
   const doc = document;
   const body = doc.body;
   if (!body) return;
 
   const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-  let prefersReducedMotion = motionQuery.matches;
+  let reduce = motionQuery.matches;
 
   const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
   const progressEl = doc.getElementById('readProgress');
   const menuToggle = doc.getElementById('menuToggle');
   const navOverlay = doc.getElementById('navOverlay');
+  const navDrawer = doc.getElementById('navDrawer');
   const navClose = doc.getElementById('navClose');
-  const navPanel = navOverlay?.querySelector('.nav-overlay__panel');
-  const focusTrapRegion = navOverlay?.querySelector('[data-focus-trap]');
-  const parallaxItems = Array.from(doc.querySelectorAll('[data-parallax-speed]'));
-
-  const canvasState = {
-    nebula: doc.getElementById('nebula'),
-    stars: doc.getElementById('stars'),
-    nebulaCtx: null,
-    starsCtx: null,
-    width: 0,
-    height: 0,
-    dpr: Math.min(window.devicePixelRatio || 1, 2),
-    particles: [],
-    comets: [],
-    spawnAccumulator: 0,
-    cometTimer: randomBetween(12000, 18000),
-    maxParticles: 0,
-    running: false,
-    lastTs: 0
-  };
-  let menuSwipeStartY = null;
-  let menuSwipeActive = false;
-  let lastFocusedBeforeMenu = null;
-  let scrollTicking = false;
+  const nebulaCanvas = doc.getElementById('nebula');
+  const nebulaCtx = nebulaCanvas?.getContext('2d', { alpha: true });
+  const starsCanvas = doc.getElementById('stars');
+  const starsCtx = starsCanvas?.getContext('2d', { alpha: true });
+  const parallaxNodes = Array.from(doc.querySelectorAll('[data-parallax-speed]'));
+  const maxParallaxSpeed = parallaxNodes.reduce((max, node) => {
+    const speed = parseFloat(node.dataset.parallaxSpeed || '0');
+    return speed > max ? speed : max;
+  }, 0);
 
   const wallets = {
     usdt: 'TSktDQkD3wmMZzd8px4pxM23JrsQ68Ee8a',
     ton: 'UQBRHJZZpfOg0SUxH_qjZxq4rNV8EedpkpKC2w1y94m0jCAc',
     btc: '1HJ8HnM7SwoBGhhwEuQU3cPC1oiZA7NNAK',
     eth: '0xc2f41255ed247cd905252e1416bee9cf2f777768'
+  };
+
+  let scrollTicking = false;
+  let lastFocusedBeforeDrawer = null;
+  let drawerTouchStart = null;
+
+  const revealTargets = Array.from(doc.querySelectorAll('.reveal, .reveal-stagger'));
+  let revealObserver = null;
+
+  const maxZ = 1200;
+  const starsState = {
+    ctx: starsCtx,
+    width: 0,
+    height: 0,
+    centerX: 0,
+    centerY: 0,
+    dpr: 1,
+    stars: [],
+    comets: [],
+    starTarget: 0,
+    starDegraded: false,
+    lastTime: performance.now(),
+    animating: false,
+    shouldAnimate: !doc.hidden,
+    fpsAccumulator: 0,
+    fpsFrames: 0,
+    fpsLastCheck: performance.now(),
+    nextComet: performance.now() + randomBetween(12000, 18000)
   };
 
   function randomBetween(min, max) {
@@ -66,16 +81,17 @@
   }
 
   function updateParallax() {
-    if (!parallaxItems.length) return;
-    if (prefersReducedMotion) {
-      parallaxItems.forEach((el) => el.style.transform = '');
+    if (!parallaxNodes.length) return;
+    if (reduce) {
+      parallaxNodes.forEach((el) => { el.style.transform = ''; });
       return;
     }
     const { scrollTop } = getDocMetrics();
-    parallaxItems.forEach((el) => {
+    parallaxNodes.forEach((el) => {
       const speed = parseFloat(el.dataset.parallaxSpeed || '0');
       if (!speed) return;
-      const offset = clamp(scrollTop * speed, -40, 40);
+      const maxOffset = maxParallaxSpeed ? (speed / maxParallaxSpeed) * 16 : 0;
+      const offset = clamp(scrollTop * speed, -maxOffset, maxOffset);
       el.style.transform = `translate3d(0, ${offset}px, 0)`;
     });
   }
@@ -96,117 +112,130 @@
     return nodes.filter((el) => !el.hasAttribute('disabled') && el.getAttribute('aria-hidden') !== 'true');
   }
 
-  function trapFocus(event) {
-    if (event.key !== 'Tab' || !focusTrapRegion) return;
-    const focusable = getFocusable(focusTrapRegion);
+  function trapDrawerFocus(event) {
+    if (event.key !== 'Tab' || !navDrawer) return;
+    const focusable = getFocusable(navDrawer);
     if (!focusable.length) {
       event.preventDefault();
+      navClose?.focus();
       return;
     }
     const first = focusable[0];
     const last = focusable[focusable.length - 1];
     const active = doc.activeElement;
     if (event.shiftKey) {
-      if (active === first || !focusTrapRegion.contains(active)) {
+      if (active === first || !navDrawer.contains(active)) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (active === last || !navDrawer.contains(active)) {
         event.preventDefault();
         first.focus();
       }
-    } else if (active === last) {
-      event.preventDefault();
-      first.focus();
     }
   }
 
-  function closeMenu() {
-    if (!navOverlay) return;
-    navOverlay.classList.remove('is-visible');
-    navOverlay.setAttribute('aria-hidden', 'true');
-    body.classList.remove('nav-open');
-    if (menuToggle) {
-      menuToggle.setAttribute('aria-expanded', 'false');
-    }
-    doc.removeEventListener('keydown', handleMenuKeydown);
-    navOverlay.removeEventListener('click', handleOverlayClick);
-    navOverlay.removeEventListener('touchstart', handleMenuTouchStart);
-    navOverlay.removeEventListener('touchmove', handleMenuTouchMove);
-    menuSwipeStartY = null;
-    menuSwipeActive = false;
-    if (lastFocusedBeforeMenu && typeof lastFocusedBeforeMenu.focus === 'function') {
-      lastFocusedBeforeMenu.focus();
-    }
-  }
-
-  function openMenu() {
-    if (!navOverlay || prefersReducedMotion === undefined) return;
-    lastFocusedBeforeMenu = doc.activeElement instanceof HTMLElement ? doc.activeElement : null;
-    navOverlay.classList.add('is-visible');
+  function openDrawer() {
+    if (!navDrawer || !navOverlay || body.classList.contains('body--nav-open')) return;
+    lastFocusedBeforeDrawer = doc.activeElement instanceof HTMLElement ? doc.activeElement : null;
+    navDrawer.setAttribute('aria-hidden', 'false');
+    navOverlay.hidden = false;
     navOverlay.setAttribute('aria-hidden', 'false');
-    body.classList.add('nav-open');
-    if (menuToggle) {
-      menuToggle.setAttribute('aria-expanded', 'true');
-    }
+    body.classList.add('body--nav-open');
+    menuToggle?.setAttribute('aria-expanded', 'true');
+
+    doc.addEventListener('keydown', handleDrawerKeydown);
     navOverlay.addEventListener('click', handleOverlayClick);
-    navOverlay.addEventListener('touchstart', handleMenuTouchStart, { passive: true });
-    navOverlay.addEventListener('touchmove', handleMenuTouchMove, { passive: true });
-    doc.addEventListener('keydown', handleMenuKeydown);
+    navDrawer.addEventListener('touchstart', handleDrawerTouchStart, { passive: true });
+    navDrawer.addEventListener('touchmove', handleDrawerTouchMove, { passive: true });
+    navDrawer.addEventListener('touchend', handleDrawerTouchEnd);
+
     requestAnimationFrame(() => {
-      const focusable = getFocusable(focusTrapRegion || navPanel || navOverlay);
-      if (focusable.length) {
-        focusable[0].focus();
-      } else if (navClose) {
-        navClose.focus();
-      }
+      const focusable = getFocusable(navDrawer);
+      const target = focusable[0] || navClose;
+      target?.focus?.();
     });
   }
 
-  function handleMenuKeydown(event) {
+  function closeDrawer() {
+    if (!navDrawer || !body.classList.contains('body--nav-open')) return;
+    body.classList.remove('body--nav-open');
+    navDrawer.setAttribute('aria-hidden', 'true');
+    menuToggle?.setAttribute('aria-expanded', 'false');
+    navOverlay?.setAttribute('aria-hidden', 'true');
+    if (navOverlay) {
+      navOverlay.hidden = true;
+    }
+
+    doc.removeEventListener('keydown', handleDrawerKeydown);
+    navOverlay?.removeEventListener('click', handleOverlayClick);
+    navDrawer.removeEventListener('touchstart', handleDrawerTouchStart);
+    navDrawer.removeEventListener('touchmove', handleDrawerTouchMove);
+    navDrawer.removeEventListener('touchend', handleDrawerTouchEnd);
+    drawerTouchStart = null;
+
+    if (lastFocusedBeforeDrawer && typeof lastFocusedBeforeDrawer.focus === 'function') {
+      lastFocusedBeforeDrawer.focus();
+    }
+  }
+
+  function handleDrawerKeydown(event) {
     if (event.key === 'Escape') {
       event.preventDefault();
-      closeMenu();
+      closeDrawer();
       return;
     }
-    trapFocus(event);
+    trapDrawerFocus(event);
   }
 
   function handleOverlayClick(event) {
-    const target = event.target;
-    if (!target) return;
-    if (target === navOverlay || target.hasAttribute('data-nav-dismiss')) {
-      closeMenu();
-    }
-    if (target instanceof HTMLAnchorElement && target.closest('.nav-overlay__panel')) {
-      closeMenu();
+    if (event.target === navOverlay) {
+      closeDrawer();
     }
   }
 
-  function handleMenuTouchStart(event) {
+  function handleDrawerClick(event) {
+    const target = event.target instanceof HTMLElement ? event.target.closest('a') : null;
+    if (target) {
+      closeDrawer();
+    }
+  }
+
+  function handleDrawerTouchStart(event) {
     if (!event.touches || event.touches.length !== 1) return;
-    menuSwipeStartY = event.touches[0].clientY;
-    menuSwipeActive = true;
+    const touch = event.touches[0];
+    drawerTouchStart = { x: touch.clientX, y: touch.clientY };
   }
 
-  function handleMenuTouchMove(event) {
-    if (!menuSwipeActive || menuSwipeStartY == null || !event.touches || event.touches.length !== 1) return;
-    const currentY = event.touches[0].clientY;
-    if (currentY - menuSwipeStartY > 60) {
-      menuSwipeActive = false;
-      closeMenu();
+  function handleDrawerTouchMove(event) {
+    if (!drawerTouchStart || !event.touches || event.touches.length !== 1) return;
+    const touch = event.touches[0];
+    const dx = touch.clientX - drawerTouchStart.x;
+    const dy = touch.clientY - drawerTouchStart.y;
+    if (dx <= -60 || dy >= 60) {
+      drawerTouchStart = null;
+      closeDrawer();
     }
+  }
+
+  function handleDrawerTouchEnd() {
+    drawerTouchStart = null;
   }
 
   function initMenu() {
-    if (!menuToggle || !navOverlay) return;
+    if (!menuToggle || !navDrawer || !navOverlay) return;
     menuToggle.addEventListener('click', () => {
       const expanded = menuToggle.getAttribute('aria-expanded') === 'true';
       if (expanded) {
-        closeMenu();
+        closeDrawer();
       } else {
-        openMenu();
+        openDrawer();
       }
     });
-    if (navClose) {
-      navClose.addEventListener('click', () => closeMenu());
-    }
+    navClose?.addEventListener('click', closeDrawer);
+    navDrawer.addEventListener('click', handleDrawerClick);
+    navOverlay.setAttribute('aria-hidden', 'true');
   }
 
   function initDonation() {
@@ -223,9 +252,7 @@
       address.value = val;
     }
 
-    if (network) {
-      network.addEventListener('change', updateAddress);
-    }
+    network?.addEventListener('change', updateAddress);
 
     if (copyBtn && address) {
       copyBtn.addEventListener('click', () => {
@@ -235,42 +262,37 @@
           setTimeout(() => {
             copyBtn.textContent = previous;
           }, 1200);
-        }).catch(() => {
-          /* clipboard might be blocked */
-        });
+        }).catch(() => {});
       });
     }
 
-    if (closeBtn && dialog) {
-      closeBtn.addEventListener('click', () => dialog.close());
-    }
-
+    closeBtn?.addEventListener('click', () => dialog.close());
     updateAddress();
   }
 
-  function initReveal() {
-    const targets = Array.from(doc.querySelectorAll('.reveal, .reveal-stagger'));
-    if (!targets.length) return;
+  function setupReveal() {
+    if (revealObserver) {
+      revealObserver.disconnect();
+      revealObserver = null;
+    }
+    if (!revealTargets.length) return;
 
-    const show = (el) => {
+    const reveal = (el) => {
       if (el.classList.contains('reveal--visible')) return;
-      el.style.willChange = 'opacity, transform';
       el.classList.add('reveal--visible');
-      setTimeout(() => {
-        el.style.removeProperty('will-change');
-      }, 600);
+      el.style.removeProperty('will-change');
     };
 
-    if (prefersReducedMotion) {
-      targets.forEach(show);
+    if (reduce) {
+      revealTargets.forEach(reveal);
       return;
     }
 
-    const observer = new IntersectionObserver((entries, obs) => {
+    revealObserver = new IntersectionObserver((entries, observer) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
-          show(entry.target);
-          obs.unobserve(entry.target);
+          reveal(entry.target);
+          observer.unobserve(entry.target);
         }
       });
     }, {
@@ -278,302 +300,262 @@
       threshold: 0.2
     });
 
-    targets.forEach((target) => observer.observe(target));
-  }
-
-  function resizeCanvases() {
-    if (!canvasState.nebula || !canvasState.stars) return;
-    const { innerWidth: width, innerHeight: height } = window;
-    canvasState.width = width;
-    canvasState.height = height;
-    canvasState.dpr = Math.min(window.devicePixelRatio || 1, 2);
-
-    [canvasState.nebula, canvasState.stars].forEach((canvas) => {
-      canvas.width = width * canvasState.dpr;
-      canvas.height = height * canvasState.dpr;
-      const ctx = canvas.getContext('2d');
-      ctx?.setTransform(canvasState.dpr, 0, 0, canvasState.dpr, 0, 0);
-    });
-
-    canvasState.nebulaCtx = canvasState.nebula.getContext('2d');
-    canvasState.starsCtx = canvasState.stars.getContext('2d');
-    canvasState.maxParticles = Math.max(12, Math.floor(width * height * 0.000012));
-    canvasState.spawnAccumulator = 0;
-  }
-
-  function spawnParticle() {
-    const centerX = canvasState.width / 2;
-    const centerY = canvasState.height * 0.45;
-    const angle = Math.random() * Math.PI * 2;
-    const velocity = randomBetween(0.02, 0.08);
-    const accel = randomBetween(0.02, 0.05);
-    canvasState.particles.push({
-      x: centerX,
-      y: centerY,
-      vx: Math.cos(angle) * velocity,
-      vy: Math.sin(angle) * velocity,
-      ax: Math.cos(angle) * accel,
-      ay: Math.sin(angle) * accel,
-      life: 0,
-      maxLife: randomBetween(3500, 6500),
-      size: randomBetween(1.2, 2.6)
+    revealTargets.forEach((el) => {
+      if (el.classList.contains('reveal--visible')) return;
+      el.style.willChange = 'opacity, transform';
+      revealObserver?.observe(el);
     });
   }
 
-  function spawnComet() {
-    if (!canvasState.starsCtx) return;
-    const centerX = canvasState.width / 2;
-    const centerY = canvasState.height * 0.45;
-    const angle = Math.random() * Math.PI * 2;
-    const velocity = randomBetween(0.12, 0.18);
-    const accel = randomBetween(0.04, 0.06);
-    canvasState.comets.push({
-      x: centerX,
-      y: centerY,
-      vx: Math.cos(angle) * velocity,
-      vy: Math.sin(angle) * velocity,
-      ax: Math.cos(angle) * accel,
-      ay: Math.sin(angle) * accel,
-      life: 0,
-      maxLife: randomBetween(5000, 8000),
-      trail: []
+  function resizeNebula() {
+    if (!nebulaCanvas || !nebulaCtx) return;
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    nebulaCanvas.width = window.innerWidth * dpr;
+    nebulaCanvas.height = window.innerHeight * dpr;
+    nebulaCtx.setTransform(1, 0, 0, 1, 0, 0);
+    nebulaCtx.scale(dpr, dpr);
+  }
+
+  function drawNebula() {
+    if (!nebulaCtx) return;
+    nebulaCtx.clearRect(0, 0, window.innerWidth, window.innerHeight);
+    const cx = window.innerWidth / 2;
+    const cy = window.innerHeight * 0.42;
+    const radius = Math.max(window.innerWidth, window.innerHeight) * 0.75;
+    const gradient = nebulaCtx.createRadialGradient(cx, cy, radius * 0.05, cx, cy, radius);
+    gradient.addColorStop(0, 'rgba(124,227,255,0.25)');
+    gradient.addColorStop(0.45, 'rgba(28,56,98,0.28)');
+    gradient.addColorStop(1, 'rgba(7,12,26,0)');
+    nebulaCtx.fillStyle = gradient;
+    nebulaCtx.fillRect(0, 0, window.innerWidth, window.innerHeight);
+  }
+
+  function resizeStarsCanvas() {
+    if (!starsCanvas || !starsState.ctx) return;
+    starsState.dpr = Math.min(window.devicePixelRatio || 1, 2);
+    starsState.width = window.innerWidth;
+    starsState.height = window.innerHeight;
+    starsCanvas.width = starsState.width * starsState.dpr;
+    starsCanvas.height = starsState.height * starsState.dpr;
+    starsState.ctx.setTransform(1, 0, 0, 1, 0, 0);
+    starsState.ctx.scale(starsState.dpr, starsState.dpr);
+    starsState.centerX = starsState.width / 2;
+    starsState.centerY = starsState.height / 2;
+  }
+
+  function createStar() {
+    return {
+      x: (Math.random() - 0.5) * starsState.width * 2,
+      y: (Math.random() - 0.5) * starsState.height * 2,
+      z: Math.random() * maxZ
+    };
+  }
+
+  function rebuildStars(forceBase = false) {
+    if (!starsState.ctx) return;
+    resizeStarsCanvas();
+    const base = window.innerWidth >= 1024 ? 1200 : 800;
+    if (forceBase || !starsState.starTarget) {
+      starsState.starTarget = base;
+      starsState.starDegraded = false;
+    } else if (!starsState.starDegraded) {
+      starsState.starTarget = base;
+    } else {
+      starsState.starTarget = Math.min(starsState.starTarget, base);
+    }
+    starsState.stars = Array.from({ length: starsState.starTarget }, createStar);
+    starsState.comets.length = 0;
+    starsState.nextComet = reduce ? Number.POSITIVE_INFINITY : performance.now() + randomBetween(12000, 18000);
+    starsState.fpsAccumulator = 0;
+    starsState.fpsFrames = 0;
+    starsState.fpsLastCheck = performance.now();
+    starsState.lastTime = performance.now();
+  }
+
+  function recycleStar(star) {
+    star.x = (Math.random() - 0.5) * starsState.width * 2;
+    star.y = (Math.random() - 0.5) * starsState.height * 2;
+    star.z = maxZ;
+  }
+
+  function spawnComet(now) {
+    if (!starsState.ctx) return;
+    starsState.comets.push({
+      startX: Math.random() * starsState.width,
+      startY: Math.random() * starsState.height,
+      angle: Math.random() * Math.PI * 2,
+      length: randomBetween(120, 200),
+      created: now,
+      duration: randomBetween(600, 900)
     });
+    starsState.nextComet = now + randomBetween(12000, 18000);
   }
 
-  function drawNebula(time) {
-    const ctx = canvasState.nebulaCtx;
-    if (!ctx) return;
-    ctx.clearRect(0, 0, canvasState.width, canvasState.height);
-    const centerX = canvasState.width / 2;
-    const centerY = canvasState.height * 0.4;
-    const radius = Math.max(canvasState.width, canvasState.height) * 0.8;
-    const gradient = ctx.createRadialGradient(centerX, centerY, 0, centerX, centerY, radius);
-    gradient.addColorStop(0, 'rgba(68,142,185,0.35)');
-    gradient.addColorStop(0.45, 'rgba(20,40,70,0.3)');
-    gradient.addColorStop(1, 'rgba(5,9,20,0)');
-    ctx.fillStyle = gradient;
-    ctx.fillRect(0, 0, canvasState.width, canvasState.height);
-
-    ctx.save();
-    ctx.translate(centerX, centerY);
-    ctx.rotate((time || 0) * 0.00004);
-    ctx.globalAlpha = 0.25;
-    const glow = ctx.createRadialGradient(0, 0, 0, 0, 0, radius * 0.65);
-    glow.addColorStop(0, 'rgba(124,227,255,0.32)');
-    glow.addColorStop(1, 'rgba(12,30,51,0)');
-    ctx.fillStyle = glow;
-    ctx.fillRect(-radius, -radius, radius * 2, radius * 2);
-    ctx.restore();
-  }
-
-  function drawParticles() {
-    const ctx = canvasState.starsCtx;
-    if (!ctx) return;
-    ctx.clearRect(0, 0, canvasState.width, canvasState.height);
-    ctx.save();
-    ctx.globalCompositeOperation = 'lighter';
-    const centerX = canvasState.width / 2;
-    const centerY = canvasState.height * 0.45;
-    const maxDist = Math.max(canvasState.width, canvasState.height) * 0.7;
-
-    for (let i = canvasState.particles.length - 1; i >= 0; i--) {
-      const p = canvasState.particles[i];
-      const dist = Math.hypot(p.x - centerX, p.y - centerY);
-      const alpha = clamp(1 - dist / maxDist, 0, 1);
-      if (alpha <= 0 || p.life >= p.maxLife || p.x < -80 || p.x > canvasState.width + 80 || p.y < -80 || p.y > canvasState.height + 80) {
-        canvasState.particles.splice(i, 1);
+  function drawComets(now) {
+    if (!starsState.ctx || !starsState.comets.length) return;
+    for (let i = starsState.comets.length - 1; i >= 0; i--) {
+      const comet = starsState.comets[i];
+      const elapsed = now - comet.created;
+      if (elapsed >= comet.duration) {
+        starsState.comets.splice(i, 1);
         continue;
       }
-      ctx.beginPath();
-      ctx.fillStyle = `rgba(124,227,255,${0.15 + alpha * 0.55})`;
-      ctx.arc(p.x, p.y, p.size * (0.6 + alpha * 0.7), 0, Math.PI * 2);
-      ctx.fill();
-    }
-
-    for (let i = canvasState.comets.length - 1; i >= 0; i--) {
-      const comet = canvasState.comets[i];
-      if (!comet.trail.length) continue;
-      const headAlpha = clamp(1 - comet.life / comet.maxLife, 0, 1);
-      const tail = comet.trail;
-      ctx.beginPath();
-      ctx.moveTo(comet.x, comet.y);
-      for (let j = 0; j < tail.length; j++) {
-        ctx.lineTo(tail[j].x, tail[j].y);
-      }
-      const gradient = ctx.createLinearGradient(comet.x, comet.y, tail[tail.length - 1].x, tail[tail.length - 1].y);
-      gradient.addColorStop(0, `rgba(124,227,255,${0.65 * headAlpha})`);
+      const progress = clamp(elapsed / comet.duration, 0, 1);
+      const alpha = 1 - progress;
+      const endX = comet.startX - Math.cos(comet.angle) * comet.length;
+      const endY = comet.startY - Math.sin(comet.angle) * comet.length;
+      const gradient = starsState.ctx.createLinearGradient(comet.startX, comet.startY, endX, endY);
+      gradient.addColorStop(0, `rgba(255,255,255,${0.75 * alpha})`);
       gradient.addColorStop(1, 'rgba(124,227,255,0)');
-      ctx.strokeStyle = gradient;
-      ctx.lineWidth = 2.2;
-      ctx.stroke();
+      starsState.ctx.beginPath();
+      starsState.ctx.strokeStyle = gradient;
+      starsState.ctx.lineWidth = 1.7;
+      starsState.ctx.moveTo(comet.startX, comet.startY);
+      starsState.ctx.lineTo(endX, endY);
+      starsState.ctx.stroke();
 
-      ctx.beginPath();
-      ctx.fillStyle = `rgba(255,255,255,${0.85 * headAlpha})`;
-      ctx.arc(comet.x, comet.y, 2.4, 0, Math.PI * 2);
-      ctx.fill();
-
-      if (headAlpha <= 0.01) {
-        canvasState.comets.splice(i, 1);
-      }
-    }
-
-    ctx.restore();
-    ctx.globalCompositeOperation = 'source-over';
-  }
-
-  function updateParticles(dt) {
-    const centerX = canvasState.width / 2;
-    const centerY = canvasState.height * 0.45;
-    const spawnRate = canvasState.maxParticles / 1000;
-    canvasState.spawnAccumulator += dt * spawnRate;
-    while (canvasState.spawnAccumulator >= 1 && canvasState.particles.length < canvasState.maxParticles) {
-      spawnParticle();
-      canvasState.spawnAccumulator -= 1;
-    }
-    canvasState.spawnAccumulator = Math.min(canvasState.spawnAccumulator, canvasState.maxParticles);
-
-    canvasState.particles.forEach((p) => {
-      p.vx += p.ax * dt;
-      p.vy += p.ay * dt;
-      p.x += p.vx * dt;
-      p.y += p.vy * dt;
-      p.life += dt;
-    });
-
-    canvasState.cometTimer -= dt;
-    if (canvasState.cometTimer <= 0) {
-      spawnComet();
-      canvasState.cometTimer = randomBetween(12000, 18000);
-    }
-
-    for (let i = canvasState.comets.length - 1; i >= 0; i--) {
-      const comet = canvasState.comets[i];
-      comet.vx += comet.ax * dt;
-      comet.vy += comet.ay * dt;
-      comet.x += comet.vx * dt;
-      comet.y += comet.vy * dt;
-      comet.life += dt;
-      comet.trail.unshift({ x: comet.x, y: comet.y });
-      if (comet.trail.length > 42) {
-        comet.trail.pop();
-      }
-      if (comet.life > comet.maxLife || comet.x < -120 || comet.x > canvasState.width + 120 || comet.y < -120 || comet.y > canvasState.height + 120) {
-        canvasState.comets.splice(i, 1);
-      }
+      starsState.ctx.beginPath();
+      starsState.ctx.fillStyle = `rgba(255,255,255,${alpha})`;
+      starsState.ctx.arc(comet.startX, comet.startY, 1.6 + 0.9 * (1 - progress), 0, Math.PI * 2);
+      starsState.ctx.fill();
     }
   }
 
-  function drawStaticBackdrop() {
-    drawNebula(0);
-    const ctx = canvasState.starsCtx;
-    if (!ctx) return;
-    ctx.clearRect(0, 0, canvasState.width, canvasState.height);
-    const count = Math.max(12, Math.floor(canvasState.maxParticles * 0.6));
-    const centerX = canvasState.width / 2;
-    const centerY = canvasState.height * 0.45;
-    const maxDist = Math.max(canvasState.width, canvasState.height) * 0.7;
-    for (let i = 0; i < count; i++) {
-      const angle = Math.random() * Math.PI * 2;
-      const distance = Math.random() * maxDist;
-      const x = centerX + Math.cos(angle) * distance;
-      const y = centerY + Math.sin(angle) * distance;
-      const alpha = clamp(1 - distance / maxDist, 0.05, 0.45);
-      ctx.beginPath();
-      ctx.fillStyle = `rgba(124,227,255,${alpha})`;
-      ctx.arc(x, y, randomBetween(1, 2.4), 0, Math.PI * 2);
-      ctx.fill();
-    }
-  }
-
-  function animationLoop(timestamp) {
-    if (!canvasState.running) return;
-    if (prefersReducedMotion || doc.hidden) {
-      canvasState.running = false;
+  function step(now) {
+    if (!starsState.ctx || !starsState.shouldAnimate) {
+      starsState.animating = false;
       return;
     }
-    if (!canvasState.lastTs) {
-      canvasState.lastTs = timestamp;
-    }
-    const dt = clamp(timestamp - canvasState.lastTs, 0, 48);
-    canvasState.lastTs = timestamp;
-    updateParticles(dt);
-    drawNebula(timestamp);
-    drawParticles();
-    requestAnimationFrame(animationLoop);
-  }
+    requestAnimationFrame(step);
 
-  function startAnimation() {
-    if (prefersReducedMotion || doc.hidden) {
-      drawStaticBackdrop();
-      return;
-    }
-    if (canvasState.running) return;
-    canvasState.running = true;
-    canvasState.lastTs = 0;
-    canvasState.particles.length = 0;
-    canvasState.comets.length = 0;
-    requestAnimationFrame(animationLoop);
-  }
+    const dtMs = Math.min(64, now - starsState.lastTime);
+    starsState.lastTime = now;
+    const dtSec = dtMs / 1000;
+    const speedBase = window.innerWidth >= 1024 ? 0.08 : 0.06;
+    const speed = speedBase * (reduce ? 0.5 : 1);
+    const rotation = (reduce ? 0 : 0.0004) * dtSec;
+    const cos = Math.cos(rotation);
+    const sin = Math.sin(rotation);
 
-  function stopAnimation() {
-    canvasState.running = false;
-  }
+    starsState.ctx.clearRect(0, 0, starsState.width, starsState.height);
+    starsState.ctx.fillStyle = 'rgba(7,12,26,0.9)';
+    starsState.ctx.fillRect(0, 0, starsState.width, starsState.height);
 
-  function initCanvases() {
-    if (!canvasState.nebula || !canvasState.stars) return;
-    resizeCanvases();
-    if (prefersReducedMotion) {
-      drawStaticBackdrop();
-    } else {
-      startAnimation();
-    }
-  }
-
-  function handleVisibility() {
-    if (doc.hidden) {
-      stopAnimation();
-    } else {
-      canvasState.lastTs = 0;
-      if (prefersReducedMotion) {
-        drawStaticBackdrop();
-      } else {
-        startAnimation();
+    for (let i = 0; i < starsState.stars.length; i++) {
+      const star = starsState.stars[i];
+      const rx = star.x * cos - star.y * sin;
+      const ry = star.x * sin + star.y * cos;
+      star.x = rx;
+      star.y = ry;
+      star.z -= speed * dtMs;
+      if (star.z <= 1) {
+        recycleStar(star);
       }
+      const k = 250 / star.z;
+      const x = star.x * k + starsState.centerX;
+      const y = star.y * k + starsState.centerY;
+      if (x < -80 || x > starsState.width + 80 || y < -80 || y > starsState.height + 80) {
+        continue;
+      }
+      const depthRatio = star.z / maxZ;
+      const alpha = Math.max(0, (1 - depthRatio) * 0.85);
+      const size = Math.max(0.6, Math.min(2.2, 2.2 - depthRatio * 2.0));
+      starsState.ctx.beginPath();
+      starsState.ctx.fillStyle = `rgba(124,227,255,${alpha})`;
+      starsState.ctx.arc(x, y, size, 0, Math.PI * 2);
+      starsState.ctx.fill();
+    }
+
+    if (!reduce && now >= starsState.nextComet) {
+      spawnComet(now);
+    }
+    if (reduce) {
+      starsState.comets.length = 0;
+      starsState.nextComet = Number.POSITIVE_INFINITY;
+    } else {
+      drawComets(now);
+    }
+
+    const fps = dtMs > 0 ? 1000 / dtMs : 60;
+    starsState.fpsAccumulator += fps;
+    starsState.fpsFrames += 1;
+    if (now - starsState.fpsLastCheck >= 3000) {
+      const average = starsState.fpsFrames ? starsState.fpsAccumulator / starsState.fpsFrames : 60;
+      if (average < 40 && starsState.stars.length > 500) {
+        starsState.starTarget = Math.max(500, Math.floor(starsState.starTarget * 0.8));
+        starsState.starDegraded = true;
+        if (starsState.stars.length > starsState.starTarget) {
+          starsState.stars.length = starsState.starTarget;
+        } else {
+          while (starsState.stars.length < starsState.starTarget) {
+            starsState.stars.push(createStar());
+          }
+        }
+      }
+      starsState.fpsAccumulator = 0;
+      starsState.fpsFrames = 0;
+      starsState.fpsLastCheck = now;
+    }
+  }
+
+  function startStars() {
+    if (!starsState.ctx) return;
+    starsState.shouldAnimate = !doc.hidden;
+    if (!starsState.shouldAnimate) return;
+    if (!starsState.animating) {
+      starsState.animating = true;
+      starsState.lastTime = performance.now();
+      requestAnimationFrame(step);
+    }
+  }
+
+  function handleVisibilityChange() {
+    starsState.shouldAnimate = !doc.hidden;
+    if (starsState.shouldAnimate) {
+      starsState.lastTime = performance.now();
+      startStars();
+    } else {
+      starsState.animating = false;
     }
   }
 
   function handleMotionChange() {
-    prefersReducedMotion = motionQuery.matches;
-    if (prefersReducedMotion) {
-      stopAnimation();
-      drawStaticBackdrop();
-      initReveal();
-      updateParallax();
+    reduce = motionQuery.matches;
+    if (reduce) {
+      starsState.comets.length = 0;
+      starsState.nextComet = Number.POSITIVE_INFINITY;
     } else {
-      canvasState.particles.length = 0;
-      canvasState.comets.length = 0;
-      startAnimation();
-      initReveal();
+      starsState.nextComet = performance.now() + randomBetween(12000, 18000);
     }
+    updateParallax();
+    setupReveal();
+  }
+
+  function handleResize() {
+    updateProgress();
+    updateParallax();
+    resizeNebula();
+    drawNebula();
+    rebuildStars();
+    startStars();
   }
 
   window.addEventListener('scroll', onScroll, { passive: true });
-  window.addEventListener('resize', () => {
-    updateProgress();
-    updateParallax();
-    resizeCanvases();
-    if (prefersReducedMotion) {
-      drawStaticBackdrop();
-    }
-  }, { passive: true });
-  doc.addEventListener('visibilitychange', handleVisibility);
-  motionQuery.addEventListener?.('change', handleMotionChange);
-  motionQuery.addListener?.(() => handleMotionChange());
+  window.addEventListener('resize', handleResize);
+  doc.addEventListener('visibilitychange', handleVisibilityChange);
+  if (typeof motionQuery.addEventListener === 'function') {
+    motionQuery.addEventListener('change', handleMotionChange);
+  } else if (typeof motionQuery.addListener === 'function') {
+    motionQuery.addListener(handleMotionChange);
+  }
 
-  initDonation();
   initMenu();
-  initReveal();
-  initCanvases();
+  initDonation();
+  setupReveal();
   updateProgress();
   updateParallax();
+  resizeNebula();
+  drawNebula();
+  rebuildStars(true);
+  startStars();
 })();


### PR DESCRIPTION
## Summary
- add a right-side navigation drawer with overlay, focus management, swipe dismissal, and body scroll lock
- simplify the desktop header to anchor links only and restore methodology step icons with fallbacks
- rebuild the starfield canvas with slow tunnel motion, comet streaks, and reduced-motion aware parallax

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68df71e0ae34832fb4543a86f9906c18