### PR TITLE
Use relative URLs for homepage navigation links

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,14 +84,14 @@
 
       <div class="drawer-group stack">
         <div class="drawer-title">Страницы</div>
-        <a href="/Evera/pages/pricing.html">Тарифы</a>
-        <a href="/Evera/pages/methodology.html">Методология</a>
-        <a href="/Evera/pages/book.html">Издание «Книга Жизни»</a>
-        <a href="/Evera/pages/eternals.html">Библиотека «Вечных»</a>
-        <a href="/Evera/pages/b2b.html">Корпоративные решения</a>
-        <a href="/Evera/pages/cases.html">Кейсы</a>
-        <a href="/Evera/pages/team.html">Команда</a>
-        <a href="/Evera/pages/roadmap.html">Роадмап</a>
+        <a href="pages/pricing.html">Тарифы</a>
+        <a href="pages/methodology.html">Методология</a>
+        <a href="pages/book.html">Издание «Книга Жизни»</a>
+        <a href="pages/eternals.html">Библиотека «Вечных»</a>
+        <a href="pages/b2b.html">Корпоративные решения</a>
+        <a href="pages/cases.html">Кейсы</a>
+        <a href="pages/team.html">Команда</a>
+        <a href="pages/roadmap.html">Роадмап</a>
       </div>
     </nav>
     <div class="nav-drawer__footer">
@@ -197,7 +197,7 @@
           </div>
         </div>
         <div class="section-cta">
-          <a class="btn ghost" href="/Evera/pages/methodology.html">Подробнее о методологии</a>
+          <a class="btn ghost" href="pages/methodology.html">Подробнее о методологии</a>
         </div>
       </div>
     </section>
@@ -225,7 +225,7 @@
           веб‑изданием с расширенным поиском и оглавлением. Редакция аккуратно собирает голосовой портрет:
           характерные слова и интонации становятся навигацией по смыслу.</p>
         <div class="section-cta">
-          <a class="btn ghost" href="/Evera/pages/book.html">Подробнее о Книге Жизни</a>
+          <a class="btn ghost" href="pages/book.html">Подробнее о Книге Жизни</a>
         </div>
       </div>
     </section>
@@ -241,7 +241,7 @@
           как интерактивный учебник; семьи и фонды - как мемориальный ИИ‑архив: экспозиции, аудиогиды, тематические
           встречи.</p>
         <div class="section-cta">
-          <a class="btn ghost" href="/Evera/pages/eternals.html">Открыть Библиотеку Вечных</a>
+          <a class="btn ghost" href="pages/eternals.html">Открыть Библиотеку Вечных</a>
         </div>
       </div>
     </section>
@@ -284,11 +284,11 @@
           <p>Смотрите тарифы EVERA или получите индивидуальный расчёт - команда ответит на почту и в Telegram.</p>
           <div class="cta-actions">
             <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20-%20Запрос%20расчёта">Запросить расчёт</a>
-            <a class="btn" href="/Evera/pages/pricing.html">Все тарифы</a>
+            <a class="btn" href="pages/pricing.html">Все тарифы</a>
             <a class="btn ghost" href="https://t.me/Solo013" target="_blank" rel="noopener">Telegram</a>
           </div>
           <div class="section-cta">
-            <a class="btn ghost" href="/Evera/pages/b2b.html">Подробнее о решениях для бизнеса</a>
+            <a class="btn ghost" href="pages/b2b.html">Подробнее о решениях для бизнеса</a>
           </div>
         </div>
       </div>
@@ -422,11 +422,11 @@
         <div class="footer-col">
           <h3>Страницы</h3>
           <ul>
-            <li><a href="/Evera/pages/methodology.html">Методология EVERA</a></li>
-            <li><a href="/Evera/pages/book.html">Книга Жизни</a></li>
-            <li><a href="/Evera/pages/eternals.html">Библиотека «Вечных»</a></li>
-            <li><a href="/Evera/pages/b2b.html">Решения для бизнеса</a></li>
-            <li><a href="/Evera/pages/pricing.html">Все тарифы</a></li>
+            <li><a href="pages/methodology.html">Методология EVERA</a></li>
+            <li><a href="pages/book.html">Книга Жизни</a></li>
+            <li><a href="pages/eternals.html">Библиотека «Вечных»</a></li>
+            <li><a href="pages/b2b.html">Решения для бизнеса</a></li>
+            <li><a href="pages/pricing.html">Все тарифы</a></li>
           </ul>
         </div>
         <div class="footer-col">
@@ -434,9 +434,9 @@
           <ul>
             <li><a href="/sitemap.xml">Карта сайта</a></li>
             <li><a href="/robots.txt">robots.txt</a></li>
-            <li><a href="/Evera/pages/team.html">Команда</a></li>
-            <li><a href="/Evera/pages/roadmap.html">Дорожная карта</a></li>
-            <li><a href="/Evera/pages/cases.html">Кейсы</a></li>
+            <li><a href="pages/team.html">Команда</a></li>
+            <li><a href="pages/roadmap.html">Дорожная карта</a></li>
+            <li><a href="pages/cases.html">Кейсы</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace `/Evera/`-prefixed internal links on the homepage with relative paths so they work on static hosts
- update navigation, CTA buttons, and footer lists to reference the shared `pages/` directory consistently

## Testing
- python3 -m http.server 8000
- curl -I http://localhost:8000/pages/pricing.html
- curl -I http://localhost:8000/pages/methodology.html
- curl -I http://localhost:8000/pages/book.html
- curl -I http://localhost:8000/pages/eternals.html
- curl -I http://localhost:8000/pages/b2b.html
- curl -I http://localhost:8000/pages/cases.html
- curl -I http://localhost:8000/pages/team.html
- curl -I http://localhost:8000/pages/roadmap.html

------
https://chatgpt.com/codex/tasks/task_e_68df8b674ff8832f90f3f1bdb4450b16