### PR TITLE
Use data-dialog attribute for final CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -371,7 +371,7 @@
         <p>EVERA сохраняет то, что обычно ускользает: голос, смысл, связь. Создайте цифровое наследие, которое
           останется доступным и понятным будущим поколениям.</p>
         <div class="cta stack">
-          <a class="btn" href="#" onclick="document.getElementById('donateDialog').showModal();return false;">Поддержать проект</a>
+          <a class="btn" href="#" data-dialog-target="donateDialog">Поддержать проект</a>
           <a class="btn ghost" href="https://t.me/sololabschannel" target="_blank" rel="noopener">Назначить интервью</a>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- switch the final CTA button to use the data-dialog target instead of inline onclick logic
- ensure the donate dialog continues to open via the declarative data attribute

## Testing
- git merge 792ec94

------
https://chatgpt.com/codex/tasks/task_e_68df8e960e48832faadbd719ee80f9f6