### PR TITLE
Adjust header navigation layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -129,6 +129,7 @@ main, header, footer, section{position:relative;z-index:1}
   align-items:center;
   gap:24px;
   padding:14px 0;
+  width:100%;
 }
 
 @media (max-width:1023px){
@@ -142,7 +143,7 @@ main, header, footer, section{position:relative;z-index:1}
 .logo img{height:26px;width:auto}
 
 .menu-toggle{
-  margin-left:auto;
+  margin:0;
   background:transparent;
   border:1px solid rgba(124,227,255,.28);
   color:var(--text);
@@ -178,6 +179,14 @@ main, header, footer, section{position:relative;z-index:1}
 }
 @media (max-width:1023px){
   .header .links{display:none}
+  .menu-toggle{order:-1}
+}
+
+@media (min-width:1024px){
+  .menu-toggle{
+    margin-left:24px;
+    margin-right:calc(0px + env(safe-area-inset-right, 0px));
+  }
 }
 
 /* overlay */

--- a/index.html
+++ b/index.html
@@ -42,7 +42,6 @@
       <a class="logo" href="#mission" aria-label="EVERA">
         <img src="evera-logo-white.svg" alt="EVERA logo">
       </a>
-      <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню" aria-expanded="false" aria-controls="navDrawer">☰</button>
       <nav class="links" id="primaryNav" aria-label="Основная навигация">
         <div class="menu-group" aria-label="Навигация по разделам страницы">
           <a href="#mission" class="active">Главная</a>
@@ -57,6 +56,7 @@
           <a href="#faq">FAQ</a>
         </div>
       </nav>
+      <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню" aria-expanded="false" aria-controls="navDrawer">☰</button>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- move the menu toggle button after the primary links so desktop layout keeps the action on the right
- update header navigation styles to fill the container width, remove conflicting auto margins, and apply responsive order/margins for the toggle

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df9eb9dc9c832f9e946f12583cb30f