### PR TITLE
Fix asset paths in subpages

### DIFF
--- a/en/pages/pricing.html
+++ b/en/pages/pricing.html
@@ -4,26 +4,26 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>EVERA Pricing | Base, Pro, Legacy plans</title>
 <meta name="description" content="Explore EVERA pricing: Base, Pro, and Legacy plans covering interviews, analytics, dialogue AI, and curator support.">
-<link rel="icon" href="/Evera/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="en" href="/Evera/en/pages/pricing.html">
-<link rel="alternate" hreflang="ru" href="/Evera/pages/pricing.html?lang=ru">
+<link rel="icon" href="/assets/icons/favicon.svg">
+<link rel="alternate" hreflang="en" href="/en/pages/pricing.html">
+<link rel="alternate" hreflang="ru" href="/pages/pricing.html?lang=ru">
 <link rel="canonical" href="https://evera.world/en/pricing">
-<link rel="stylesheet" href="/Evera/css/styles.css">
+<link rel="stylesheet" href="/css/styles.css">
 </head>
 <body>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html?lang=en">Methodology</a>
-      <a class="btn" href="/Evera/pages/cases.html?lang=en">Cases</a>
-      <a class="btn" href="/Evera/pages/team.html?lang=en">Team</a>
-      <a class="btn" href="/Evera/pages/roadmap.html?lang=en">Roadmap</a>
-      <a class="btn" href="/Evera/pages/book.html?lang=en">Book of Life</a>
-      <a class="btn" href="/Evera/pages/b2b.html?lang=en">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html?lang=en">Eternals</a>
-      <a class="btn" href="/Evera/en/pages/pricing.html">Pricing</a>
+      <a class="btn" href="/index.html">Home</a>
+      <a class="btn" href="/pages/methodology.html?lang=en">Methodology</a>
+      <a class="btn" href="/pages/cases.html?lang=en">Cases</a>
+      <a class="btn" href="/pages/team.html?lang=en">Team</a>
+      <a class="btn" href="/pages/roadmap.html?lang=en">Roadmap</a>
+      <a class="btn" href="/pages/book.html?lang=en">Book of Life</a>
+      <a class="btn" href="/pages/b2b.html?lang=en">B2B</a>
+      <a class="btn" href="/pages/eternals.html?lang=en">Eternals</a>
+      <a class="btn" href="/en/pages/pricing.html">Pricing</a>
       <select class="lang-switch" aria-label="Switch language"><option value="en" selected>EN</option><option value="ru">RU</option></select>
     </div>
   </nav>
@@ -36,7 +36,7 @@
         <p class="lead">Русская версия страницы доступна по ссылке ниже.</p>
         <div class="cta-block">
           <div class="cta-actions">
-            <a class="btn" href="/Evera/pages/pricing.html">Открыть тарифы на русском</a>
+            <a class="btn" href="/pages/pricing.html">Открыть тарифы на русском</a>
           </div>
         </div>
       </div>
@@ -128,5 +128,5 @@
   </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
-<script src="/Evera/js/app.js"></script>
+<script src="/js/app.js"></script>
 </body></html>

--- a/pages/b2b.html
+++ b/pages/b2b.html
@@ -4,28 +4,28 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>EVERA для бизнеса | корпоративная память и брендовые истории</title>
 <meta name="description" content="Решения EVERA для бизнеса: цифровой голос основателя, база знаний бренда, обучение и наследие руководителей. Узнайте о модулях, внедрении и тарифах.">
-<link rel="icon" href="/Evera/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/Evera/pages/b2b.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/Evera/pages/b2b.html?lang=en">
+<link rel="icon" href="/assets/icons/favicon.svg">
+<link rel="alternate" hreflang="ru" href="/pages/b2b.html?lang=ru">
+<link rel="alternate" hreflang="en" href="/pages/b2b.html?lang=en">
 <link rel="canonical" href="https://evera.world/b2b">
-<link rel="stylesheet" href="/Evera/css/styles.css">
+<link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="b2b">
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
-      <a class="btn" href="/Evera/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/Evera/pages/pricing.html" data-href-en="/Evera/en/pages/pricing.html">Тарифы</a>
+      <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="/pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
+      <a class="btn" href="/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
+      <a class="btn" href="/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
@@ -122,7 +122,7 @@
           <p>Посмотрите тарифы EVERA и обсудите индивидуальный расчёт для вашей команды.</p>
           <div class="cta-actions">
             <a class="btn" href="mailto:b2b@evera.world?subject=EVERA%20B2B%20-%20Запрос%20расчёта">Запросить расчёт</a>
-            <a class="btn" href="/Evera/pages/pricing.html" data-href-ru="/Evera/pages/pricing.html" data-href-en="/Evera/en/pages/pricing.html">Тарифы EVERA</a>
+            <a class="btn" href="/pages/pricing.html" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы EVERA</a>
             <a class="btn ghost" href="https://t.me/Solo013" target="_blank" rel="noopener">Telegram</a>
           </div>
         </div>
@@ -220,7 +220,7 @@
           <p>Explore EVERA pricing or reach out for a bespoke scope tailored to your organisation.</p>
           <div class="cta-actions">
             <a class="btn" href="mailto:b2b@evera.world?subject=EVERA%20B2B%20-%20Request%20a%20quote">Request a quote</a>
-            <a class="btn" href="/Evera/en/pages/pricing.html">EVERA Pricing</a>
+            <a class="btn" href="/en/pages/pricing.html">EVERA Pricing</a>
             <a class="btn ghost" href="https://t.me/Solo013" target="_blank" rel="noopener">Telegram</a>
           </div>
         </div>
@@ -229,5 +229,5 @@
   </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
-<script src="/Evera/js/app.js"></script>
+<script src="/js/app.js"></script>
 </body></html>

--- a/pages/book.html
+++ b/pages/book.html
@@ -4,28 +4,28 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Книга Жизни | издание EVERA</title>
 <meta name="description" content="Книга Жизни EVERA: структурированная биография с голосами, фотографиями и интерактивными QR-ссылками. Узнайте, как мы создаём издание и какие форматы доступны.">
-<link rel="icon" href="/Evera/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/Evera/pages/book.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/Evera/pages/book.html?lang=en">
+<link rel="icon" href="/assets/icons/favicon.svg">
+<link rel="alternate" hreflang="ru" href="/pages/book.html?lang=ru">
+<link rel="alternate" hreflang="en" href="/pages/book.html?lang=en">
 <link rel="canonical" href="https://evera.world/book">
-<link rel="stylesheet" href="/Evera/css/styles.css">
+<link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="book">
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
-      <a class="btn" href="/Evera/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/Evera/pages/pricing.html" data-href-en="/Evera/en/pages/pricing.html">Тарифы</a>
+      <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="/pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
+      <a class="btn" href="/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
+      <a class="btn" href="/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
@@ -175,5 +175,5 @@
   </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
-<script src="/Evera/js/app.js"></script>
+<script src="/js/app.js"></script>
 </body></html>

--- a/pages/cases.html
+++ b/pages/cases.html
@@ -4,28 +4,28 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Кейсы EVERA | цифровые биографии для семей, музеев и бизнеса</title>
 <meta name="description" content="Реализованные кейсы EVERA: семейные архивы, музеи, корпоративные лидеры. Узнайте, какие задачи решает цифровая биография и как выглядит результат на русском и английском языках.">
-<link rel="icon" href="/Evera/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/Evera/pages/cases.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/Evera/pages/cases.html?lang=en">
+<link rel="icon" href="/assets/icons/favicon.svg">
+<link rel="alternate" hreflang="ru" href="/pages/cases.html?lang=ru">
+<link rel="alternate" hreflang="en" href="/pages/cases.html?lang=en">
 <link rel="canonical" href="https://evera.world/cases">
-<link rel="stylesheet" href="/Evera/css/styles.css">
+<link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="cases">
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
-      <a class="btn" href="/Evera/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/Evera/pages/pricing.html" data-href-en="/Evera/en/pages/pricing.html">Тарифы</a>
+      <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="/pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
+      <a class="btn" href="/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
+      <a class="btn" href="/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
@@ -169,5 +169,5 @@
   </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
-<script src="/Evera/js/app.js"></script>
+<script src="/js/app.js"></script>
 </body></html>

--- a/pages/eternals.html
+++ b/pages/eternals.html
@@ -4,28 +4,28 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Библиотека «Вечных» | публичные цифровые портреты EVERA</title>
 <meta name="description" content="Библиотека «Вечных»: открытая коллекция цифровых портретов исторических фигур, меценатов и педагогов. Узнайте о миссии, критериях отбора и способах участия.">
-<link rel="icon" href="/Evera/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/Evera/pages/eternals.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/Evera/pages/eternals.html?lang=en">
+<link rel="icon" href="/assets/icons/favicon.svg">
+<link rel="alternate" hreflang="ru" href="/pages/eternals.html?lang=ru">
+<link rel="alternate" hreflang="en" href="/pages/eternals.html?lang=en">
 <link rel="canonical" href="https://evera.world/eternals">
-<link rel="stylesheet" href="/Evera/css/styles.css">
+<link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="eternals">
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
-      <a class="btn" href="/Evera/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/Evera/pages/pricing.html" data-href-en="/Evera/en/pages/pricing.html">Тарифы</a>
+      <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="/pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
+      <a class="btn" href="/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
+      <a class="btn" href="/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
@@ -213,5 +213,5 @@
   </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
-<script src="/Evera/js/app.js"></script>
+<script src="/js/app.js"></script>
 </body></html>

--- a/pages/methodology.html
+++ b/pages/methodology.html
@@ -4,28 +4,28 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Методология EVERA | цифровая биография и диалог</title>
 <meta name="description" content="Методология EVERA: интервью 150+ вопросов, аналитика голоса и эмоций, редакторская валидация и диалоговый ИИ. Узнайте, как создаётся цифровая биография на русском и английском языках.">
-<link rel="icon" href="/Evera/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/Evera/pages/methodology.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/Evera/pages/methodology.html?lang=en">
+<link rel="icon" href="/assets/icons/favicon.svg">
+<link rel="alternate" hreflang="ru" href="/pages/methodology.html?lang=ru">
+<link rel="alternate" hreflang="en" href="/pages/methodology.html?lang=en">
 <link rel="canonical" href="https://evera.world/methodology">
-<link rel="stylesheet" href="/Evera/css/styles.css">
+<link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="methodology">
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
-      <a class="btn" href="/Evera/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/Evera/pages/pricing.html" data-href-en="/Evera/en/pages/pricing.html">Тарифы</a>
+      <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="/pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
+      <a class="btn" href="/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
+      <a class="btn" href="/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
@@ -219,5 +219,5 @@
   </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
-<script src="/Evera/js/app.js"></script>
+<script src="/js/app.js"></script>
 </body></html>

--- a/pages/pricing.html
+++ b/pages/pricing.html
@@ -4,26 +4,26 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Тарифы EVERA | цифровое наследие под ключ</title>
 <meta name="description" content="Тарифы EVERA: Base, Pro и Legacy. Интервью, аналитика, диалоговый ИИ и сопровождение для семей и брендов.">
-<link rel="icon" href="/Evera/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/Evera/pages/pricing.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/Evera/en/pages/pricing.html">
+<link rel="icon" href="/assets/icons/favicon.svg">
+<link rel="alternate" hreflang="ru" href="/pages/pricing.html?lang=ru">
+<link rel="alternate" hreflang="en" href="/en/pages/pricing.html">
 <link rel="canonical" href="https://evera.world/pricing">
-<link rel="stylesheet" href="/Evera/css/styles.css">
+<link rel="stylesheet" href="/css/styles.css">
 </head>
 <body>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Главная</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
-      <a class="btn" href="/Evera/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/Evera/pages/pricing.html" data-href-en="/Evera/en/pages/pricing.html">Тарифы</a>
+      <a class="btn" href="/index.html" data-i18n="nav.home">Главная</a>
+      <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="/pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
+      <a class="btn" href="/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
+      <a class="btn" href="/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
@@ -199,5 +199,5 @@
   </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
-<script src="/Evera/js/app.js"></script>
+<script src="/js/app.js"></script>
 </body></html>

--- a/pages/roadmap.html
+++ b/pages/roadmap.html
@@ -4,28 +4,28 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Дорожная карта EVERA | развитие продукта и исследований</title>
 <meta name="description" content="Планы развития EVERA: новые релизы, исследовательские треки, международные партнёрства. Ознакомьтесь с дорожной картой на русском и английском языках.">
-<link rel="icon" href="/Evera/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/Evera/pages/roadmap.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/Evera/pages/roadmap.html?lang=en">
+<link rel="icon" href="/assets/icons/favicon.svg">
+<link rel="alternate" hreflang="ru" href="/pages/roadmap.html?lang=ru">
+<link rel="alternate" hreflang="en" href="/pages/roadmap.html?lang=en">
 <link rel="canonical" href="https://evera.world/roadmap">
-<link rel="stylesheet" href="/Evera/css/styles.css">
+<link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="roadmap">
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
-      <a class="btn" href="/Evera/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/Evera/pages/pricing.html" data-href-en="/Evera/en/pages/pricing.html">Тарифы</a>
+      <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="/pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
+      <a class="btn" href="/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
+      <a class="btn" href="/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
@@ -147,5 +147,5 @@
   </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
-<script src="/Evera/js/app.js"></script>
+<script src="/js/app.js"></script>
 </body></html>

--- a/pages/team.html
+++ b/pages/team.html
@@ -4,28 +4,28 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Команда EVERA | кураторы памяти, редакторы, инженеры</title>
 <meta name="description" content="Познакомьтесь с командой EVERA: кураторы памяти, редакторы, инженеры ИИ и экспертный совет. Узнайте, как мы бережно создаём цифровые портреты и Книги Жизни.">
-<link rel="icon" href="/Evera/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/Evera/pages/team.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/Evera/pages/team.html?lang=en">
+<link rel="icon" href="/assets/icons/favicon.svg">
+<link rel="alternate" hreflang="ru" href="/pages/team.html?lang=ru">
+<link rel="alternate" hreflang="en" href="/pages/team.html?lang=en">
 <link rel="canonical" href="https://evera.world/team">
-<link rel="stylesheet" href="/Evera/css/styles.css">
+<link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="team">
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <nav class="nav">
-    <div class="brand"><img class="logo" src="/Evera/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+    <div class="brand"><img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
     <div class="links">
-      <a class="btn" href="/Evera/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/Evera/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/Evera/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/Evera/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/Evera/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/Evera/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/Evera/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/Evera/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
-      <a class="btn" href="/Evera/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/Evera/pages/pricing.html" data-href-en="/Evera/en/pages/pricing.html">Тарифы</a>
+      <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
+      <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
+      <a class="btn" href="/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
+      <a class="btn" href="/pages/team.html" data-i18n="nav.team">Команда</a>
+      <a class="btn" href="/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
+      <a class="btn" href="/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
+      <a class="btn" href="/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
+      <a class="btn" href="/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
+      <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
   </nav>
@@ -209,5 +209,5 @@
   </article>
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
-<script src="/Evera/js/app.js"></script>
+<script src="/js/app.js"></script>
 </body></html>


### PR DESCRIPTION
## Summary
- remove the outdated `/Evera/` prefix from asset, navigation, and alternate language links across the RU and EN static pages
- point favicon, stylesheet, and script tags to their real locations so that resources load both locally and on production hosting

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68df9ebaf43c832f9f949ae4e614cbf7