### PR TITLE
Align subpage headers with shared nav layout

### DIFF
--- a/en/pages/pricing.html
+++ b/en/pages/pricing.html
@@ -12,8 +12,10 @@
 </head>
 <body>
 <header class="header">
-  <nav class="nav">
-    <div class="brand"><img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+  <div class="nav container">
+    <a class="brand" href="/index.html" aria-label="EVERA">
+      <img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b>
+    </a>
     <div class="links">
       <a class="btn" href="/index.html">Home</a>
       <a class="btn" href="/pages/methodology.html?lang=en">Methodology</a>
@@ -26,7 +28,7 @@
       <a class="btn" href="/en/pages/pricing.html">Pricing</a>
       <select class="lang-switch" aria-label="Switch language"><option value="en" selected>EN</option><option value="ru">RU</option></select>
     </div>
-  </nav>
+  </div>
 </header>
 <main>
   <article class="page-intro" data-lang="ru" lang="ru" hidden>

--- a/pages/b2b.html
+++ b/pages/b2b.html
@@ -14,8 +14,10 @@
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
-  <nav class="nav">
-    <div class="brand"><img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+  <div class="nav container">
+    <a class="brand" href="/index.html" aria-label="EVERA">
+      <img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b>
+    </a>
     <div class="links">
       <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
       <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
@@ -28,7 +30,7 @@
       <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
-  </nav>
+  </div>
 </header>
 <main>
   <article class="page-intro" data-lang="ru" lang="ru">

--- a/pages/book.html
+++ b/pages/book.html
@@ -14,8 +14,10 @@
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
-  <nav class="nav">
-    <div class="brand"><img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+  <div class="nav container">
+    <a class="brand" href="/index.html" aria-label="EVERA">
+      <img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b>
+    </a>
     <div class="links">
       <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
       <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
@@ -28,7 +30,7 @@
       <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
-  </nav>
+  </div>
 </header>
 <main>
   <article class="page-intro" data-lang="ru" lang="ru">

--- a/pages/cases.html
+++ b/pages/cases.html
@@ -14,8 +14,10 @@
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
-  <nav class="nav">
-    <div class="brand"><img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+  <div class="nav container">
+    <a class="brand" href="/index.html" aria-label="EVERA">
+      <img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b>
+    </a>
     <div class="links">
       <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
       <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
@@ -28,7 +30,7 @@
       <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
-  </nav>
+  </div>
 </header>
 <main>
   <article class="page-intro" data-lang="ru" lang="ru">

--- a/pages/eternals.html
+++ b/pages/eternals.html
@@ -14,8 +14,10 @@
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
-  <nav class="nav">
-    <div class="brand"><img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+  <div class="nav container">
+    <a class="brand" href="/index.html" aria-label="EVERA">
+      <img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b>
+    </a>
     <div class="links">
       <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
       <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
@@ -28,7 +30,7 @@
       <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
-  </nav>
+  </div>
 </header>
 <main>
   <article class="page-intro" data-lang="ru" lang="ru">

--- a/pages/methodology.html
+++ b/pages/methodology.html
@@ -14,8 +14,10 @@
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
-  <nav class="nav">
-    <div class="brand"><img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+  <div class="nav container">
+    <a class="brand" href="/index.html" aria-label="EVERA">
+      <img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b>
+    </a>
     <div class="links">
       <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
       <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
@@ -28,7 +30,7 @@
       <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
-  </nav>
+  </div>
 </header>
 <main>
   <article class="page-intro" data-lang="ru" lang="ru">

--- a/pages/pricing.html
+++ b/pages/pricing.html
@@ -12,8 +12,10 @@
 </head>
 <body>
 <header class="header">
-  <nav class="nav">
-    <div class="brand"><img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+  <div class="nav container">
+    <a class="brand" href="/index.html" aria-label="EVERA">
+      <img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b>
+    </a>
     <div class="links">
       <a class="btn" href="/index.html" data-i18n="nav.home">Главная</a>
       <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
@@ -26,7 +28,7 @@
       <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
-  </nav>
+  </div>
 </header>
 <main>
   <article class="page-intro" data-lang="ru" lang="ru">

--- a/pages/roadmap.html
+++ b/pages/roadmap.html
@@ -14,8 +14,10 @@
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
-  <nav class="nav">
-    <div class="brand"><img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+  <div class="nav container">
+    <a class="brand" href="/index.html" aria-label="EVERA">
+      <img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b>
+    </a>
     <div class="links">
       <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
       <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
@@ -28,7 +30,7 @@
       <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
-  </nav>
+  </div>
 </header>
 <main>
   <article class="page-intro" data-lang="ru" lang="ru">

--- a/pages/team.html
+++ b/pages/team.html
@@ -14,8 +14,10 @@
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
-  <nav class="nav">
-    <div class="brand"><img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b></div>
+  <div class="nav container">
+    <a class="brand" href="/index.html" aria-label="EVERA">
+      <img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b>
+    </a>
     <div class="links">
       <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
       <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
@@ -28,7 +30,7 @@
       <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
       <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
     </div>
-  </nav>
+  </div>
 </header>
 <main>
   <article class="page-intro" data-lang="ru" lang="ru">


### PR DESCRIPTION
## Summary
- wrap the locale page headers with the shared `.nav container` structure from the homepage
- retain existing navigation links and language switchers so locale URLs stay intact

## Testing
- python -m http.server 8000 (spot-checked layout in browser)


------
https://chatgpt.com/codex/tasks/task_e_68dfa3afc394832f87c7bdbdfbdfaaa3