### PR TITLE
Adjust header navigation padding handling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -128,8 +128,14 @@ main, header, footer, section{position:relative;z-index:1}
   display:flex;
   align-items:center;
   gap:24px;
-  padding:14px 0;
+  padding-block:14px;
   width:100%;
+}
+
+@media (min-width:1024px){
+  .header .nav.container{
+    padding-inline:24px;
+  }
 }
 
 @media (max-width:1023px){


### PR DESCRIPTION
## Summary
- adjust `.nav` padding to use `padding-block` so the container's inline spacing is preserved
- add a desktop media query to keep 24px inline padding while retaining mobile safe-area rules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfd4aa8b64832f9c8132e447f9f5e9