### PR TITLE
Ensure donate dialog styles apply only when open

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -551,7 +551,9 @@ h3{font-size:var(--h3); line-height:1.3; margin:0;}
 
 .dialog-backdrop{background:rgba(5,9,20,.65)}
 
-dialog#donateDialog{
+dialog#donateDialog:not([open]){display:none}
+
+dialog#donateDialog[open]{
   border:1px solid rgba(124,227,255,.3);
   border-radius:16px;
   padding:28px;


### PR DESCRIPTION
## Summary
- scope the donate dialog styling to its open state so it only displays when active
- explicitly hide the dialog while closed to prevent flashes before initialization

## Testing
- Manual verification via Playwright script opening and closing the dialog

------
https://chatgpt.com/codex/tasks/task_e_68dfd6024210832f89cc66b97e53f0d1