### PR TITLE
Adjust CTA button spacing for mobile and desktop

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -482,9 +482,9 @@ h3{font-size:var(--h3); line-height:1.3; margin:0;}
   .timeline li::before{left:-20px;}
 }
 
-.cta{display:flex;flex-direction:column;align-items:stretch;flex-wrap:wrap;gap:0;--stack-gap:var(--space-4);}
-.cta.stack > * + *{margin-top:var(--stack-gap);}
-.cta.stack .btn + .btn{margin-top:0;}
+.cta{display:flex;flex-direction:column;align-items:stretch;flex-wrap:wrap;gap:var(--stack-gap);--stack-gap:var(--space-4);}
+.cta.stack > * + *{margin-top:0;}
+.cta.stack .btn + .btn{margin-top:var(--space-3);}
 .cta-block{margin-top:0;background:rgba(12,30,51,.35);border:1px solid rgba(124,227,255,.18);border-radius:16px;padding:var(--space-6);box-shadow:0 18px 48px rgba(7,18,40,.35);display:flex;flex-direction:column;gap:var(--space-4);}
 .cta-block p{margin:0;color:var(--muted)}
 .cta-actions{display:flex;flex-wrap:wrap;gap:var(--space-3);margin:0;}
@@ -534,7 +534,7 @@ h3{font-size:var(--h3); line-height:1.3; margin:0;}
 }
 
 @media (min-width:768px){
-  .cta{flex-direction:row;align-items:center;gap:var(--space-3);}
+  .cta{flex-direction:row;align-items:center;gap:var(--space-4);}
   .cta.stack > * + *{margin-top:0;}
   .cta.stack .btn + .btn{margin-top:0;}
 }


### PR DESCRIPTION
## Summary
- restore vertical spacing between stacked CTA buttons on mobile by limiting the reset to desktop layouts
- add flex gap for CTA stacks so the column layout keeps consistent spacing and widen the desktop horizontal gap

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfd6a8b0cc832f9c3bb4f463780d94