### PR TITLE
Unify site header on interior pages

### DIFF
--- a/en/pages/pricing.html
+++ b/en/pages/pricing.html
@@ -10,26 +10,129 @@
 <link rel="canonical" href="https://evera.world/en/pricing">
 <link rel="stylesheet" href="/css/styles.css">
 </head>
-<body>
+<body data-nebula="pricing">
+<div class="read-progress" id="readProgress" aria-hidden="true"></div>
+<canvas id="nebula" aria-hidden="true"></canvas>
+<canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <div class="nav container">
-    <a class="brand" href="/index.html" aria-label="EVERA">
-      <img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b>
+    <a class="logo" href="../../index.html#mission" aria-label="EVERA">
+      <img src="../../evera-logo-white.svg" alt="EVERA logo">
     </a>
-    <div class="links">
-      <a class="btn" href="/index.html">Home</a>
-      <a class="btn" href="/pages/methodology.html?lang=en">Methodology</a>
-      <a class="btn" href="/pages/cases.html?lang=en">Cases</a>
-      <a class="btn" href="/pages/team.html?lang=en">Team</a>
-      <a class="btn" href="/pages/roadmap.html?lang=en">Roadmap</a>
-      <a class="btn" href="/pages/book.html?lang=en">Book of Life</a>
-      <a class="btn" href="/pages/b2b.html?lang=en">B2B</a>
-      <a class="btn" href="/pages/eternals.html?lang=en">Eternals</a>
-      <a class="btn" href="/en/pages/pricing.html">Pricing</a>
-      <select class="lang-switch" aria-label="Switch language"><option value="en" selected>EN</option><option value="ru">RU</option></select>
-    </div>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Menu / Меню" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <nav class="links" id="primaryNav" aria-label="Primary navigation">
+      <article data-lang="ru" lang="ru" hidden>
+        <div class="menu-group" aria-label="Навигация по разделам страницы">
+          <a href="../../index.html#mission">Главная</a>
+          <a href="../../index.html#what">Что такое</a>
+          <a href="../../index.html#process">Процесс</a>
+          <a href="../../index.html#ai">ИИ</a>
+          <a href="../../index.html#book">Книга Жизни</a>
+          <a href="../../index.html#eternals">Вечные</a>
+          <a href="../../index.html#audience">Для кого</a>
+          <a href="../../index.html#b2b">Бизнес</a>
+          <a href="../../index.html#ethics">Этика</a>
+          <a href="../../index.html#faq">FAQ</a>
+        </div>
+      </article>
+      <article data-lang="en" lang="en">
+        <div class="menu-group" aria-label="Navigate page sections">
+          <a href="../../index.html#mission">Home</a>
+          <a href="../../index.html#what">What</a>
+          <a href="../../index.html#process">Process</a>
+          <a href="../../index.html#ai">AI</a>
+          <a href="../../index.html#book">Book of Life</a>
+          <a href="../../index.html#eternals">Eternals</a>
+          <a href="../../index.html#audience">Audience</a>
+          <a href="../../index.html#b2b">Business</a>
+          <a href="../../index.html#ethics">Ethics</a>
+          <a href="../../index.html#faq">FAQ</a>
+        </div>
+      </article>
+    </nav>
+    <select class="lang-switch" aria-label="Switch language">
+      <option value="ru">RU</option>
+      <option value="en" selected>EN</option>
+    </select>
   </div>
 </header>
+<div class="nav-overlay" id="navOverlay" hidden></div>
+<aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
+  <div class="nav-drawer__header">
+    <h2 id="menuTitle">
+      <span data-lang="ru" lang="ru">Меню</span>
+      <span data-lang="en" lang="en">Menu</span>
+    </h2>
+    <button class="nav-drawer__close" id="navClose" aria-label="Close menu / Закрыть меню">✕</button>
+  </div>
+
+  <nav class="nav-drawer__body stack" aria-label="Site navigation">
+    <article data-lang="ru" lang="ru" class="stack">
+      <div class="drawer-group stack">
+        <div class="drawer-title">Разделы</div>
+        <a href="../../index.html#mission">Главная</a>
+        <a href="../../index.html#what">Что такое</a>
+        <a href="../../index.html#process">Процесс</a>
+        <a href="../../index.html#ai">ИИ</a>
+        <a href="../../index.html#book">Книга Жизни</a>
+        <a href="../../index.html#eternals">Вечные</a>
+        <a href="../../index.html#audience">Для кого</a>
+        <a href="../../index.html#b2b">Бизнес</a>
+        <a href="../../index.html#ethics">Этика</a>
+        <a href="../../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Страницы</div>
+        <a href="../../pages/pricing.html" data-href-ru="../../pages/pricing.html" data-href-en="pricing.html">Тарифы</a>
+        <a href="../../pages/methodology.html" data-href-ru="../../pages/methodology.html" data-href-en="../../pages/methodology.html?lang=en">Методология</a>
+        <a href="../../pages/book.html" data-href-ru="../../pages/book.html" data-href-en="../../pages/book.html?lang=en">Издание «Книга Жизни»</a>
+        <a href="../../pages/eternals.html" data-href-ru="../../pages/eternals.html" data-href-en="../../pages/eternals.html?lang=en">Библиотека «Вечных»</a>
+        <a href="../../pages/b2b.html" data-href-ru="../../pages/b2b.html" data-href-en="../../pages/b2b.html?lang=en">Корпоративные решения</a>
+        <a href="../../pages/cases.html" data-href-ru="../../pages/cases.html" data-href-en="../../pages/cases.html?lang=en">Кейсы</a>
+        <a href="../../pages/team.html" data-href-ru="../../pages/team.html" data-href-en="../../pages/team.html?lang=en">Команда</a>
+        <a href="../../pages/roadmap.html" data-href-ru="../../pages/roadmap.html" data-href-en="../../pages/roadmap.html?lang=en">Роадмап</a>
+      </div>
+    </article>
+
+    <article data-lang="en" lang="en" class="stack">
+      <div class="drawer-group stack">
+        <div class="drawer-title">Sections</div>
+        <a href="../../index.html#mission">Home</a>
+        <a href="../../index.html#what">What</a>
+        <a href="../../index.html#process">Process</a>
+        <a href="../../index.html#ai">AI</a>
+        <a href="../../index.html#book">Book of Life</a>
+        <a href="../../index.html#eternals">Eternals</a>
+        <a href="../../index.html#audience">Audience</a>
+        <a href="../../index.html#b2b">Business</a>
+        <a href="../../index.html#ethics">Ethics</a>
+        <a href="../../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Pages</div>
+        <a href="pricing.html" data-href-ru="../../pages/pricing.html" data-href-en="pricing.html" class="active">Pricing</a>
+        <a href="../../pages/methodology.html?lang=en" data-href-ru="../../pages/methodology.html" data-href-en="../../pages/methodology.html?lang=en">Methodology</a>
+        <a href="../../pages/book.html?lang=en" data-href-ru="../../pages/book.html" data-href-en="../../pages/book.html?lang=en">Book of Life</a>
+        <a href="../../pages/eternals.html?lang=en" data-href-ru="../../pages/eternals.html" data-href-en="../../pages/eternals.html?lang=en">Eternals Library</a>
+        <a href="../../pages/b2b.html?lang=en" data-href-ru="../../pages/b2b.html" data-href-en="../../pages/b2b.html?lang=en">B2B solutions</a>
+        <a href="../../pages/cases.html?lang=en" data-href-ru="../../pages/cases.html" data-href-en="../../pages/cases.html?lang=en">Cases</a>
+        <a href="../../pages/team.html?lang=en" data-href-ru="../../pages/team.html" data-href-en="../../pages/team.html?lang=en">Team</a>
+        <a href="../../pages/roadmap.html?lang=en" data-href-ru="../../pages/roadmap.html" data-href-en="../../pages/roadmap.html?lang=en">Roadmap</a>
+      </div>
+    </article>
+  </nav>
+  <div class="nav-drawer__footer">
+    <a class="drawer-brand" href="../../index.html#mission" aria-label="EVERA">
+      <img src="../../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
+    </a>
+    <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
+      <span data-lang="ru" lang="ru">Telegram-канал</span>
+      <span data-lang="en" lang="en">Telegram channel</span>
+    </a>
+  </div>
+</aside>
 <main>
   <article class="page-intro" data-lang="ru" lang="ru" hidden>
     <section class="section">

--- a/pages/b2b.html
+++ b/pages/b2b.html
@@ -11,27 +11,128 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="b2b">
+<div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <div class="nav container">
-    <a class="brand" href="/index.html" aria-label="EVERA">
-      <img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b>
+    <a class="logo" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA logo">
     </a>
-    <div class="links">
-      <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
-      <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
-      <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
-    </div>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню / Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <nav class="links" id="primaryNav" aria-label="Основная навигация">
+      <article data-lang="ru" lang="ru">
+        <div class="menu-group" aria-label="Навигация по разделам страницы">
+          <a href="../index.html#mission">Главная</a>
+          <a href="../index.html#what">Что такое</a>
+          <a href="../index.html#process">Процесс</a>
+          <a href="../index.html#ai">ИИ</a>
+          <a href="../index.html#book">Книга Жизни</a>
+          <a href="../index.html#eternals">Вечные</a>
+          <a href="../index.html#audience">Для кого</a>
+          <a href="../index.html#b2b">Бизнес</a>
+          <a href="../index.html#ethics">Этика</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+      <article data-lang="en" lang="en" hidden>
+        <div class="menu-group" aria-label="Navigate page sections">
+          <a href="../index.html#mission">Home</a>
+          <a href="../index.html#what">What</a>
+          <a href="../index.html#process">Process</a>
+          <a href="../index.html#ai">AI</a>
+          <a href="../index.html#book">Book of Life</a>
+          <a href="../index.html#eternals">Eternals</a>
+          <a href="../index.html#audience">Audience</a>
+          <a href="../index.html#b2b">Business</a>
+          <a href="../index.html#ethics">Ethics</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+    </nav>
+    <select class="lang-switch" aria-label="Switch language">
+      <option value="ru">RU</option>
+      <option value="en">EN</option>
+    </select>
   </div>
 </header>
+<div class="nav-overlay" id="navOverlay" hidden></div>
+<aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
+  <div class="nav-drawer__header">
+    <h2 id="menuTitle">
+      <span data-lang="ru" lang="ru">Меню</span>
+      <span data-lang="en" lang="en" hidden>Menu</span>
+    </h2>
+    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню / Close menu">✕</button>
+  </div>
+
+  <nav class="nav-drawer__body stack" aria-label="Навигация по сайту">
+    <article data-lang="ru" lang="ru" class="stack">
+      <div class="drawer-group stack">
+        <div class="drawer-title">Разделы</div>
+        <a href="../index.html#mission">Главная</a>
+        <a href="../index.html#what">Что такое</a>
+        <a href="../index.html#process">Процесс</a>
+        <a href="../index.html#ai">ИИ</a>
+        <a href="../index.html#book">Книга Жизни</a>
+        <a href="../index.html#eternals">Вечные</a>
+        <a href="../index.html#audience">Для кого</a>
+        <a href="../index.html#b2b">Бизнес</a>
+        <a href="../index.html#ethics">Этика</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Страницы</div>
+        <a href="pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Тарифы</a>
+        <a href="methodology.html" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Методология</a>
+        <a href="book.html" data-href-ru="book.html" data-href-en="book.html?lang=en">Издание «Книга Жизни»</a>
+        <a href="eternals.html" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Библиотека «Вечных»</a>
+        <a href="b2b.html" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en" class="active">Корпоративные решения</a>
+        <a href="cases.html" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Кейсы</a>
+        <a href="team.html" data-href-ru="team.html" data-href-en="team.html?lang=en">Команда</a>
+        <a href="roadmap.html" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Роадмап</a>
+      </div>
+    </article>
+
+    <article data-lang="en" lang="en" class="stack" hidden>
+      <div class="drawer-group stack">
+        <div class="drawer-title">Sections</div>
+        <a href="../index.html#mission">Home</a>
+        <a href="../index.html#what">What</a>
+        <a href="../index.html#process">Process</a>
+        <a href="../index.html#ai">AI</a>
+        <a href="../index.html#book">Book of Life</a>
+        <a href="../index.html#eternals">Eternals</a>
+        <a href="../index.html#audience">Audience</a>
+        <a href="../index.html#b2b">Business</a>
+        <a href="../index.html#ethics">Ethics</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Pages</div>
+        <a href="../en/pages/pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Pricing</a>
+        <a href="methodology.html?lang=en" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Methodology</a>
+        <a href="book.html?lang=en" data-href-ru="book.html" data-href-en="book.html?lang=en">Book of Life</a>
+        <a href="eternals.html?lang=en" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Eternals Library</a>
+        <a href="b2b.html?lang=en" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en" class="active">B2B solutions</a>
+        <a href="cases.html?lang=en" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Cases</a>
+        <a href="team.html?lang=en" data-href-ru="team.html" data-href-en="team.html?lang=en">Team</a>
+        <a href="roadmap.html?lang=en" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Roadmap</a>
+      </div>
+    </article>
+  </nav>
+  <div class="nav-drawer__footer">
+    <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
+    </a>
+    <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
+      <span data-lang="ru" lang="ru">Telegram-канал</span>
+      <span data-lang="en" lang="en" hidden>Telegram channel</span>
+    </a>
+  </div>
+</aside>
 <main>
   <article class="page-intro" data-lang="ru" lang="ru">
     <section class="section">

--- a/pages/book.html
+++ b/pages/book.html
@@ -11,27 +11,128 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="book">
+<div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <div class="nav container">
-    <a class="brand" href="/index.html" aria-label="EVERA">
-      <img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b>
+    <a class="logo" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA logo">
     </a>
-    <div class="links">
-      <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
-      <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
-      <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
-    </div>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню / Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <nav class="links" id="primaryNav" aria-label="Основная навигация">
+      <article data-lang="ru" lang="ru">
+        <div class="menu-group" aria-label="Навигация по разделам страницы">
+          <a href="../index.html#mission">Главная</a>
+          <a href="../index.html#what">Что такое</a>
+          <a href="../index.html#process">Процесс</a>
+          <a href="../index.html#ai">ИИ</a>
+          <a href="../index.html#book">Книга Жизни</a>
+          <a href="../index.html#eternals">Вечные</a>
+          <a href="../index.html#audience">Для кого</a>
+          <a href="../index.html#b2b">Бизнес</a>
+          <a href="../index.html#ethics">Этика</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+      <article data-lang="en" lang="en" hidden>
+        <div class="menu-group" aria-label="Navigate page sections">
+          <a href="../index.html#mission">Home</a>
+          <a href="../index.html#what">What</a>
+          <a href="../index.html#process">Process</a>
+          <a href="../index.html#ai">AI</a>
+          <a href="../index.html#book">Book of Life</a>
+          <a href="../index.html#eternals">Eternals</a>
+          <a href="../index.html#audience">Audience</a>
+          <a href="../index.html#b2b">Business</a>
+          <a href="../index.html#ethics">Ethics</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+    </nav>
+    <select class="lang-switch" aria-label="Switch language">
+      <option value="ru">RU</option>
+      <option value="en">EN</option>
+    </select>
   </div>
 </header>
+<div class="nav-overlay" id="navOverlay" hidden></div>
+<aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
+  <div class="nav-drawer__header">
+    <h2 id="menuTitle">
+      <span data-lang="ru" lang="ru">Меню</span>
+      <span data-lang="en" lang="en" hidden>Menu</span>
+    </h2>
+    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню / Close menu">✕</button>
+  </div>
+
+  <nav class="nav-drawer__body stack" aria-label="Навигация по сайту">
+    <article data-lang="ru" lang="ru" class="stack">
+      <div class="drawer-group stack">
+        <div class="drawer-title">Разделы</div>
+        <a href="../index.html#mission">Главная</a>
+        <a href="../index.html#what">Что такое</a>
+        <a href="../index.html#process">Процесс</a>
+        <a href="../index.html#ai">ИИ</a>
+        <a href="../index.html#book">Книга Жизни</a>
+        <a href="../index.html#eternals">Вечные</a>
+        <a href="../index.html#audience">Для кого</a>
+        <a href="../index.html#b2b">Бизнес</a>
+        <a href="../index.html#ethics">Этика</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Страницы</div>
+        <a href="pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Тарифы</a>
+        <a href="methodology.html" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Методология</a>
+        <a href="book.html" data-href-ru="book.html" data-href-en="book.html?lang=en" class="active">Издание «Книга Жизни»</a>
+        <a href="eternals.html" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Библиотека «Вечных»</a>
+        <a href="b2b.html" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">Корпоративные решения</a>
+        <a href="cases.html" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Кейсы</a>
+        <a href="team.html" data-href-ru="team.html" data-href-en="team.html?lang=en">Команда</a>
+        <a href="roadmap.html" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Роадмап</a>
+      </div>
+    </article>
+
+    <article data-lang="en" lang="en" class="stack" hidden>
+      <div class="drawer-group stack">
+        <div class="drawer-title">Sections</div>
+        <a href="../index.html#mission">Home</a>
+        <a href="../index.html#what">What</a>
+        <a href="../index.html#process">Process</a>
+        <a href="../index.html#ai">AI</a>
+        <a href="../index.html#book">Book of Life</a>
+        <a href="../index.html#eternals">Eternals</a>
+        <a href="../index.html#audience">Audience</a>
+        <a href="../index.html#b2b">Business</a>
+        <a href="../index.html#ethics">Ethics</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Pages</div>
+        <a href="../en/pages/pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Pricing</a>
+        <a href="methodology.html?lang=en" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Methodology</a>
+        <a href="book.html?lang=en" data-href-ru="book.html" data-href-en="book.html?lang=en" class="active">Book of Life</a>
+        <a href="eternals.html?lang=en" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Eternals Library</a>
+        <a href="b2b.html?lang=en" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">B2B solutions</a>
+        <a href="cases.html?lang=en" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Cases</a>
+        <a href="team.html?lang=en" data-href-ru="team.html" data-href-en="team.html?lang=en">Team</a>
+        <a href="roadmap.html?lang=en" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Roadmap</a>
+      </div>
+    </article>
+  </nav>
+  <div class="nav-drawer__footer">
+    <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
+    </a>
+    <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
+      <span data-lang="ru" lang="ru">Telegram-канал</span>
+      <span data-lang="en" lang="en" hidden>Telegram channel</span>
+    </a>
+  </div>
+</aside>
 <main>
   <article class="page-intro" data-lang="ru" lang="ru">
     <section class="section">

--- a/pages/cases.html
+++ b/pages/cases.html
@@ -11,27 +11,128 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="cases">
+<div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <div class="nav container">
-    <a class="brand" href="/index.html" aria-label="EVERA">
-      <img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b>
+    <a class="logo" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA logo">
     </a>
-    <div class="links">
-      <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
-      <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
-      <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
-    </div>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню / Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <nav class="links" id="primaryNav" aria-label="Основная навигация">
+      <article data-lang="ru" lang="ru">
+        <div class="menu-group" aria-label="Навигация по разделам страницы">
+          <a href="../index.html#mission">Главная</a>
+          <a href="../index.html#what">Что такое</a>
+          <a href="../index.html#process">Процесс</a>
+          <a href="../index.html#ai">ИИ</a>
+          <a href="../index.html#book">Книга Жизни</a>
+          <a href="../index.html#eternals">Вечные</a>
+          <a href="../index.html#audience">Для кого</a>
+          <a href="../index.html#b2b">Бизнес</a>
+          <a href="../index.html#ethics">Этика</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+      <article data-lang="en" lang="en" hidden>
+        <div class="menu-group" aria-label="Navigate page sections">
+          <a href="../index.html#mission">Home</a>
+          <a href="../index.html#what">What</a>
+          <a href="../index.html#process">Process</a>
+          <a href="../index.html#ai">AI</a>
+          <a href="../index.html#book">Book of Life</a>
+          <a href="../index.html#eternals">Eternals</a>
+          <a href="../index.html#audience">Audience</a>
+          <a href="../index.html#b2b">Business</a>
+          <a href="../index.html#ethics">Ethics</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+    </nav>
+    <select class="lang-switch" aria-label="Switch language">
+      <option value="ru">RU</option>
+      <option value="en">EN</option>
+    </select>
   </div>
 </header>
+<div class="nav-overlay" id="navOverlay" hidden></div>
+<aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
+  <div class="nav-drawer__header">
+    <h2 id="menuTitle">
+      <span data-lang="ru" lang="ru">Меню</span>
+      <span data-lang="en" lang="en" hidden>Menu</span>
+    </h2>
+    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню / Close menu">✕</button>
+  </div>
+
+  <nav class="nav-drawer__body stack" aria-label="Навигация по сайту">
+    <article data-lang="ru" lang="ru" class="stack">
+      <div class="drawer-group stack">
+        <div class="drawer-title">Разделы</div>
+        <a href="../index.html#mission">Главная</a>
+        <a href="../index.html#what">Что такое</a>
+        <a href="../index.html#process">Процесс</a>
+        <a href="../index.html#ai">ИИ</a>
+        <a href="../index.html#book">Книга Жизни</a>
+        <a href="../index.html#eternals">Вечные</a>
+        <a href="../index.html#audience">Для кого</a>
+        <a href="../index.html#b2b">Бизнес</a>
+        <a href="../index.html#ethics">Этика</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Страницы</div>
+        <a href="pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Тарифы</a>
+        <a href="methodology.html" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Методология</a>
+        <a href="book.html" data-href-ru="book.html" data-href-en="book.html?lang=en">Издание «Книга Жизни»</a>
+        <a href="eternals.html" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Библиотека «Вечных»</a>
+        <a href="b2b.html" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">Корпоративные решения</a>
+        <a href="cases.html" data-href-ru="cases.html" data-href-en="cases.html?lang=en" class="active">Кейсы</a>
+        <a href="team.html" data-href-ru="team.html" data-href-en="team.html?lang=en">Команда</a>
+        <a href="roadmap.html" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Роадмап</a>
+      </div>
+    </article>
+
+    <article data-lang="en" lang="en" class="stack" hidden>
+      <div class="drawer-group stack">
+        <div class="drawer-title">Sections</div>
+        <a href="../index.html#mission">Home</a>
+        <a href="../index.html#what">What</a>
+        <a href="../index.html#process">Process</a>
+        <a href="../index.html#ai">AI</a>
+        <a href="../index.html#book">Book of Life</a>
+        <a href="../index.html#eternals">Eternals</a>
+        <a href="../index.html#audience">Audience</a>
+        <a href="../index.html#b2b">Business</a>
+        <a href="../index.html#ethics">Ethics</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Pages</div>
+        <a href="../en/pages/pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Pricing</a>
+        <a href="methodology.html?lang=en" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Methodology</a>
+        <a href="book.html?lang=en" data-href-ru="book.html" data-href-en="book.html?lang=en">Book of Life</a>
+        <a href="eternals.html?lang=en" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Eternals Library</a>
+        <a href="b2b.html?lang=en" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">B2B solutions</a>
+        <a href="cases.html?lang=en" data-href-ru="cases.html" data-href-en="cases.html?lang=en" class="active">Cases</a>
+        <a href="team.html?lang=en" data-href-ru="team.html" data-href-en="team.html?lang=en">Team</a>
+        <a href="roadmap.html?lang=en" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Roadmap</a>
+      </div>
+    </article>
+  </nav>
+  <div class="nav-drawer__footer">
+    <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
+    </a>
+    <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
+      <span data-lang="ru" lang="ru">Telegram-канал</span>
+      <span data-lang="en" lang="en" hidden>Telegram channel</span>
+    </a>
+  </div>
+</aside>
 <main>
   <article class="page-intro" data-lang="ru" lang="ru">
     <section class="section">

--- a/pages/eternals.html
+++ b/pages/eternals.html
@@ -11,27 +11,128 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="eternals">
+<div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <div class="nav container">
-    <a class="brand" href="/index.html" aria-label="EVERA">
-      <img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b>
+    <a class="logo" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA logo">
     </a>
-    <div class="links">
-      <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
-      <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
-      <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
-    </div>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню / Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <nav class="links" id="primaryNav" aria-label="Основная навигация">
+      <article data-lang="ru" lang="ru">
+        <div class="menu-group" aria-label="Навигация по разделам страницы">
+          <a href="../index.html#mission">Главная</a>
+          <a href="../index.html#what">Что такое</a>
+          <a href="../index.html#process">Процесс</a>
+          <a href="../index.html#ai">ИИ</a>
+          <a href="../index.html#book">Книга Жизни</a>
+          <a href="../index.html#eternals">Вечные</a>
+          <a href="../index.html#audience">Для кого</a>
+          <a href="../index.html#b2b">Бизнес</a>
+          <a href="../index.html#ethics">Этика</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+      <article data-lang="en" lang="en" hidden>
+        <div class="menu-group" aria-label="Navigate page sections">
+          <a href="../index.html#mission">Home</a>
+          <a href="../index.html#what">What</a>
+          <a href="../index.html#process">Process</a>
+          <a href="../index.html#ai">AI</a>
+          <a href="../index.html#book">Book of Life</a>
+          <a href="../index.html#eternals">Eternals</a>
+          <a href="../index.html#audience">Audience</a>
+          <a href="../index.html#b2b">Business</a>
+          <a href="../index.html#ethics">Ethics</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+    </nav>
+    <select class="lang-switch" aria-label="Switch language">
+      <option value="ru">RU</option>
+      <option value="en">EN</option>
+    </select>
   </div>
 </header>
+<div class="nav-overlay" id="navOverlay" hidden></div>
+<aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
+  <div class="nav-drawer__header">
+    <h2 id="menuTitle">
+      <span data-lang="ru" lang="ru">Меню</span>
+      <span data-lang="en" lang="en" hidden>Menu</span>
+    </h2>
+    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню / Close menu">✕</button>
+  </div>
+
+  <nav class="nav-drawer__body stack" aria-label="Навигация по сайту">
+    <article data-lang="ru" lang="ru" class="stack">
+      <div class="drawer-group stack">
+        <div class="drawer-title">Разделы</div>
+        <a href="../index.html#mission">Главная</a>
+        <a href="../index.html#what">Что такое</a>
+        <a href="../index.html#process">Процесс</a>
+        <a href="../index.html#ai">ИИ</a>
+        <a href="../index.html#book">Книга Жизни</a>
+        <a href="../index.html#eternals">Вечные</a>
+        <a href="../index.html#audience">Для кого</a>
+        <a href="../index.html#b2b">Бизнес</a>
+        <a href="../index.html#ethics">Этика</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Страницы</div>
+        <a href="pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Тарифы</a>
+        <a href="methodology.html" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Методология</a>
+        <a href="book.html" data-href-ru="book.html" data-href-en="book.html?lang=en">Издание «Книга Жизни»</a>
+        <a href="eternals.html" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en" class="active">Библиотека «Вечных»</a>
+        <a href="b2b.html" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">Корпоративные решения</a>
+        <a href="cases.html" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Кейсы</a>
+        <a href="team.html" data-href-ru="team.html" data-href-en="team.html?lang=en">Команда</a>
+        <a href="roadmap.html" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Роадмап</a>
+      </div>
+    </article>
+
+    <article data-lang="en" lang="en" class="stack" hidden>
+      <div class="drawer-group stack">
+        <div class="drawer-title">Sections</div>
+        <a href="../index.html#mission">Home</a>
+        <a href="../index.html#what">What</a>
+        <a href="../index.html#process">Process</a>
+        <a href="../index.html#ai">AI</a>
+        <a href="../index.html#book">Book of Life</a>
+        <a href="../index.html#eternals">Eternals</a>
+        <a href="../index.html#audience">Audience</a>
+        <a href="../index.html#b2b">Business</a>
+        <a href="../index.html#ethics">Ethics</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Pages</div>
+        <a href="../en/pages/pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Pricing</a>
+        <a href="methodology.html?lang=en" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Methodology</a>
+        <a href="book.html?lang=en" data-href-ru="book.html" data-href-en="book.html?lang=en">Book of Life</a>
+        <a href="eternals.html?lang=en" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en" class="active">Eternals Library</a>
+        <a href="b2b.html?lang=en" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">B2B solutions</a>
+        <a href="cases.html?lang=en" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Cases</a>
+        <a href="team.html?lang=en" data-href-ru="team.html" data-href-en="team.html?lang=en">Team</a>
+        <a href="roadmap.html?lang=en" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Roadmap</a>
+      </div>
+    </article>
+  </nav>
+  <div class="nav-drawer__footer">
+    <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
+    </a>
+    <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
+      <span data-lang="ru" lang="ru">Telegram-канал</span>
+      <span data-lang="en" lang="en" hidden>Telegram channel</span>
+    </a>
+  </div>
+</aside>
 <main>
   <article class="page-intro" data-lang="ru" lang="ru">
     <section class="section">

--- a/pages/methodology.html
+++ b/pages/methodology.html
@@ -11,27 +11,128 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="methodology">
+<div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <div class="nav container">
-    <a class="brand" href="/index.html" aria-label="EVERA">
-      <img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b>
+    <a class="logo" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA logo">
     </a>
-    <div class="links">
-      <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
-      <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
-      <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
-    </div>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню / Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <nav class="links" id="primaryNav" aria-label="Основная навигация">
+      <article data-lang="ru" lang="ru">
+        <div class="menu-group" aria-label="Навигация по разделам страницы">
+          <a href="../index.html#mission">Главная</a>
+          <a href="../index.html#what">Что такое</a>
+          <a href="../index.html#process">Процесс</a>
+          <a href="../index.html#ai">ИИ</a>
+          <a href="../index.html#book">Книга Жизни</a>
+          <a href="../index.html#eternals">Вечные</a>
+          <a href="../index.html#audience">Для кого</a>
+          <a href="../index.html#b2b">Бизнес</a>
+          <a href="../index.html#ethics">Этика</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+      <article data-lang="en" lang="en" hidden>
+        <div class="menu-group" aria-label="Navigate page sections">
+          <a href="../index.html#mission">Home</a>
+          <a href="../index.html#what">What</a>
+          <a href="../index.html#process">Process</a>
+          <a href="../index.html#ai">AI</a>
+          <a href="../index.html#book">Book of Life</a>
+          <a href="../index.html#eternals">Eternals</a>
+          <a href="../index.html#audience">Audience</a>
+          <a href="../index.html#b2b">Business</a>
+          <a href="../index.html#ethics">Ethics</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+    </nav>
+    <select class="lang-switch" aria-label="Switch language">
+      <option value="ru">RU</option>
+      <option value="en">EN</option>
+    </select>
   </div>
 </header>
+<div class="nav-overlay" id="navOverlay" hidden></div>
+<aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
+  <div class="nav-drawer__header">
+    <h2 id="menuTitle">
+      <span data-lang="ru" lang="ru">Меню</span>
+      <span data-lang="en" lang="en" hidden>Menu</span>
+    </h2>
+    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню / Close menu">✕</button>
+  </div>
+
+  <nav class="nav-drawer__body stack" aria-label="Навигация по сайту">
+    <article data-lang="ru" lang="ru" class="stack">
+      <div class="drawer-group stack">
+        <div class="drawer-title">Разделы</div>
+        <a href="../index.html#mission">Главная</a>
+        <a href="../index.html#what">Что такое</a>
+        <a href="../index.html#process">Процесс</a>
+        <a href="../index.html#ai">ИИ</a>
+        <a href="../index.html#book">Книга Жизни</a>
+        <a href="../index.html#eternals">Вечные</a>
+        <a href="../index.html#audience">Для кого</a>
+        <a href="../index.html#b2b">Бизнес</a>
+        <a href="../index.html#ethics">Этика</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Страницы</div>
+        <a href="pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Тарифы</a>
+        <a href="methodology.html" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en" class="active">Методология</a>
+        <a href="book.html" data-href-ru="book.html" data-href-en="book.html?lang=en">Издание «Книга Жизни»</a>
+        <a href="eternals.html" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Библиотека «Вечных»</a>
+        <a href="b2b.html" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">Корпоративные решения</a>
+        <a href="cases.html" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Кейсы</a>
+        <a href="team.html" data-href-ru="team.html" data-href-en="team.html?lang=en">Команда</a>
+        <a href="roadmap.html" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Роадмап</a>
+      </div>
+    </article>
+
+    <article data-lang="en" lang="en" class="stack" hidden>
+      <div class="drawer-group stack">
+        <div class="drawer-title">Sections</div>
+        <a href="../index.html#mission">Home</a>
+        <a href="../index.html#what">What</a>
+        <a href="../index.html#process">Process</a>
+        <a href="../index.html#ai">AI</a>
+        <a href="../index.html#book">Book of Life</a>
+        <a href="../index.html#eternals">Eternals</a>
+        <a href="../index.html#audience">Audience</a>
+        <a href="../index.html#b2b">Business</a>
+        <a href="../index.html#ethics">Ethics</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Pages</div>
+        <a href="../en/pages/pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Pricing</a>
+        <a href="methodology.html?lang=en" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en" class="active">Methodology</a>
+        <a href="book.html?lang=en" data-href-ru="book.html" data-href-en="book.html?lang=en">Book of Life</a>
+        <a href="eternals.html?lang=en" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Eternals Library</a>
+        <a href="b2b.html?lang=en" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">B2B solutions</a>
+        <a href="cases.html?lang=en" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Cases</a>
+        <a href="team.html?lang=en" data-href-ru="team.html" data-href-en="team.html?lang=en">Team</a>
+        <a href="roadmap.html?lang=en" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Roadmap</a>
+      </div>
+    </article>
+  </nav>
+  <div class="nav-drawer__footer">
+    <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
+    </a>
+    <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
+      <span data-lang="ru" lang="ru">Telegram-канал</span>
+      <span data-lang="en" lang="en" hidden>Telegram channel</span>
+    </a>
+  </div>
+</aside>
 <main>
   <article class="page-intro" data-lang="ru" lang="ru">
     <section class="section">

--- a/pages/pricing.html
+++ b/pages/pricing.html
@@ -10,26 +10,129 @@
 <link rel="canonical" href="https://evera.world/pricing">
 <link rel="stylesheet" href="/css/styles.css">
 </head>
-<body>
+<body data-nebula="pricing">
+<div class="read-progress" id="readProgress" aria-hidden="true"></div>
+<canvas id="nebula" aria-hidden="true"></canvas>
+<canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <div class="nav container">
-    <a class="brand" href="/index.html" aria-label="EVERA">
-      <img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b>
+    <a class="logo" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA logo">
     </a>
-    <div class="links">
-      <a class="btn" href="/index.html" data-i18n="nav.home">Главная</a>
-      <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
-      <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
-      <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
-    </div>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню / Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <nav class="links" id="primaryNav" aria-label="Основная навигация">
+      <article data-lang="ru" lang="ru">
+        <div class="menu-group" aria-label="Навигация по разделам страницы">
+          <a href="../index.html#mission">Главная</a>
+          <a href="../index.html#what">Что такое</a>
+          <a href="../index.html#process">Процесс</a>
+          <a href="../index.html#ai">ИИ</a>
+          <a href="../index.html#book">Книга Жизни</a>
+          <a href="../index.html#eternals">Вечные</a>
+          <a href="../index.html#audience">Для кого</a>
+          <a href="../index.html#b2b">Бизнес</a>
+          <a href="../index.html#ethics">Этика</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+      <article data-lang="en" lang="en" hidden>
+        <div class="menu-group" aria-label="Navigate page sections">
+          <a href="../index.html#mission">Home</a>
+          <a href="../index.html#what">What</a>
+          <a href="../index.html#process">Process</a>
+          <a href="../index.html#ai">AI</a>
+          <a href="../index.html#book">Book of Life</a>
+          <a href="../index.html#eternals">Eternals</a>
+          <a href="../index.html#audience">Audience</a>
+          <a href="../index.html#b2b">Business</a>
+          <a href="../index.html#ethics">Ethics</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+    </nav>
+    <select class="lang-switch" aria-label="Switch language">
+      <option value="ru">RU</option>
+      <option value="en">EN</option>
+    </select>
   </div>
 </header>
+<div class="nav-overlay" id="navOverlay" hidden></div>
+<aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
+  <div class="nav-drawer__header">
+    <h2 id="menuTitle">
+      <span data-lang="ru" lang="ru">Меню</span>
+      <span data-lang="en" lang="en" hidden>Menu</span>
+    </h2>
+    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню / Close menu">✕</button>
+  </div>
+
+  <nav class="nav-drawer__body stack" aria-label="Навигация по сайту">
+    <article data-lang="ru" lang="ru" class="stack">
+      <div class="drawer-group stack">
+        <div class="drawer-title">Разделы</div>
+        <a href="../index.html#mission">Главная</a>
+        <a href="../index.html#what">Что такое</a>
+        <a href="../index.html#process">Процесс</a>
+        <a href="../index.html#ai">ИИ</a>
+        <a href="../index.html#book">Книга Жизни</a>
+        <a href="../index.html#eternals">Вечные</a>
+        <a href="../index.html#audience">Для кого</a>
+        <a href="../index.html#b2b">Бизнес</a>
+        <a href="../index.html#ethics">Этика</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Страницы</div>
+        <a href="pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html" class="active">Тарифы</a>
+        <a href="methodology.html" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Методология</a>
+        <a href="book.html" data-href-ru="book.html" data-href-en="book.html?lang=en">Издание «Книга Жизни»</a>
+        <a href="eternals.html" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Библиотека «Вечных»</a>
+        <a href="b2b.html" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">Корпоративные решения</a>
+        <a href="cases.html" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Кейсы</a>
+        <a href="team.html" data-href-ru="team.html" data-href-en="team.html?lang=en">Команда</a>
+        <a href="roadmap.html" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Роадмап</a>
+      </div>
+    </article>
+
+    <article data-lang="en" lang="en" class="stack" hidden>
+      <div class="drawer-group stack">
+        <div class="drawer-title">Sections</div>
+        <a href="../index.html#mission">Home</a>
+        <a href="../index.html#what">What</a>
+        <a href="../index.html#process">Process</a>
+        <a href="../index.html#ai">AI</a>
+        <a href="../index.html#book">Book of Life</a>
+        <a href="../index.html#eternals">Eternals</a>
+        <a href="../index.html#audience">Audience</a>
+        <a href="../index.html#b2b">Business</a>
+        <a href="../index.html#ethics">Ethics</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Pages</div>
+        <a href="../en/pages/pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html" class="active">Pricing</a>
+        <a href="methodology.html?lang=en" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Methodology</a>
+        <a href="book.html?lang=en" data-href-ru="book.html" data-href-en="book.html?lang=en">Book of Life</a>
+        <a href="eternals.html?lang=en" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Eternals Library</a>
+        <a href="b2b.html?lang=en" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">B2B solutions</a>
+        <a href="cases.html?lang=en" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Cases</a>
+        <a href="team.html?lang=en" data-href-ru="team.html" data-href-en="team.html?lang=en">Team</a>
+        <a href="roadmap.html?lang=en" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Roadmap</a>
+      </div>
+    </article>
+  </nav>
+  <div class="nav-drawer__footer">
+    <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
+    </a>
+    <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
+      <span data-lang="ru" lang="ru">Telegram-канал</span>
+      <span data-lang="en" lang="en" hidden>Telegram channel</span>
+    </a>
+  </div>
+</aside>
 <main>
   <article class="page-intro" data-lang="ru" lang="ru">
     <section class="section">

--- a/pages/roadmap.html
+++ b/pages/roadmap.html
@@ -11,27 +11,128 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="roadmap">
+<div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <div class="nav container">
-    <a class="brand" href="/index.html" aria-label="EVERA">
-      <img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b>
+    <a class="logo" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA logo">
     </a>
-    <div class="links">
-      <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
-      <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
-      <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
-    </div>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню / Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <nav class="links" id="primaryNav" aria-label="Основная навигация">
+      <article data-lang="ru" lang="ru">
+        <div class="menu-group" aria-label="Навигация по разделам страницы">
+          <a href="../index.html#mission">Главная</a>
+          <a href="../index.html#what">Что такое</a>
+          <a href="../index.html#process">Процесс</a>
+          <a href="../index.html#ai">ИИ</a>
+          <a href="../index.html#book">Книга Жизни</a>
+          <a href="../index.html#eternals">Вечные</a>
+          <a href="../index.html#audience">Для кого</a>
+          <a href="../index.html#b2b">Бизнес</a>
+          <a href="../index.html#ethics">Этика</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+      <article data-lang="en" lang="en" hidden>
+        <div class="menu-group" aria-label="Navigate page sections">
+          <a href="../index.html#mission">Home</a>
+          <a href="../index.html#what">What</a>
+          <a href="../index.html#process">Process</a>
+          <a href="../index.html#ai">AI</a>
+          <a href="../index.html#book">Book of Life</a>
+          <a href="../index.html#eternals">Eternals</a>
+          <a href="../index.html#audience">Audience</a>
+          <a href="../index.html#b2b">Business</a>
+          <a href="../index.html#ethics">Ethics</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+    </nav>
+    <select class="lang-switch" aria-label="Switch language">
+      <option value="ru">RU</option>
+      <option value="en">EN</option>
+    </select>
   </div>
 </header>
+<div class="nav-overlay" id="navOverlay" hidden></div>
+<aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
+  <div class="nav-drawer__header">
+    <h2 id="menuTitle">
+      <span data-lang="ru" lang="ru">Меню</span>
+      <span data-lang="en" lang="en" hidden>Menu</span>
+    </h2>
+    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню / Close menu">✕</button>
+  </div>
+
+  <nav class="nav-drawer__body stack" aria-label="Навигация по сайту">
+    <article data-lang="ru" lang="ru" class="stack">
+      <div class="drawer-group stack">
+        <div class="drawer-title">Разделы</div>
+        <a href="../index.html#mission">Главная</a>
+        <a href="../index.html#what">Что такое</a>
+        <a href="../index.html#process">Процесс</a>
+        <a href="../index.html#ai">ИИ</a>
+        <a href="../index.html#book">Книга Жизни</a>
+        <a href="../index.html#eternals">Вечные</a>
+        <a href="../index.html#audience">Для кого</a>
+        <a href="../index.html#b2b">Бизнес</a>
+        <a href="../index.html#ethics">Этика</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Страницы</div>
+        <a href="pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Тарифы</a>
+        <a href="methodology.html" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Методология</a>
+        <a href="book.html" data-href-ru="book.html" data-href-en="book.html?lang=en">Издание «Книга Жизни»</a>
+        <a href="eternals.html" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Библиотека «Вечных»</a>
+        <a href="b2b.html" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">Корпоративные решения</a>
+        <a href="cases.html" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Кейсы</a>
+        <a href="team.html" data-href-ru="team.html" data-href-en="team.html?lang=en">Команда</a>
+        <a href="roadmap.html" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en" class="active">Роадмап</a>
+      </div>
+    </article>
+
+    <article data-lang="en" lang="en" class="stack" hidden>
+      <div class="drawer-group stack">
+        <div class="drawer-title">Sections</div>
+        <a href="../index.html#mission">Home</a>
+        <a href="../index.html#what">What</a>
+        <a href="../index.html#process">Process</a>
+        <a href="../index.html#ai">AI</a>
+        <a href="../index.html#book">Book of Life</a>
+        <a href="../index.html#eternals">Eternals</a>
+        <a href="../index.html#audience">Audience</a>
+        <a href="../index.html#b2b">Business</a>
+        <a href="../index.html#ethics">Ethics</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Pages</div>
+        <a href="../en/pages/pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Pricing</a>
+        <a href="methodology.html?lang=en" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Methodology</a>
+        <a href="book.html?lang=en" data-href-ru="book.html" data-href-en="book.html?lang=en">Book of Life</a>
+        <a href="eternals.html?lang=en" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Eternals Library</a>
+        <a href="b2b.html?lang=en" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">B2B solutions</a>
+        <a href="cases.html?lang=en" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Cases</a>
+        <a href="team.html?lang=en" data-href-ru="team.html" data-href-en="team.html?lang=en">Team</a>
+        <a href="roadmap.html?lang=en" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en" class="active">Roadmap</a>
+      </div>
+    </article>
+  </nav>
+  <div class="nav-drawer__footer">
+    <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
+    </a>
+    <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
+      <span data-lang="ru" lang="ru">Telegram-канал</span>
+      <span data-lang="en" lang="en" hidden>Telegram channel</span>
+    </a>
+  </div>
+</aside>
 <main>
   <article class="page-intro" data-lang="ru" lang="ru">
     <section class="section">

--- a/pages/team.html
+++ b/pages/team.html
@@ -11,27 +11,128 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="team">
+<div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <div class="nav container">
-    <a class="brand" href="/index.html" aria-label="EVERA">
-      <img class="logo" src="/assets/icons/favicon.svg" alt="EVERA"><b>EVERA</b>
+    <a class="logo" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA logo">
     </a>
-    <div class="links">
-      <a class="btn" href="/index.html" data-i18n="nav.home">Home</a>
-      <a class="btn" href="/pages/methodology.html" data-i18n="nav.method">Методология</a>
-      <a class="btn" href="/pages/cases.html" data-i18n="nav.cases">Кейсы</a>
-      <a class="btn" href="/pages/team.html" data-i18n="nav.team">Команда</a>
-      <a class="btn" href="/pages/roadmap.html" data-i18n="nav.roadmap">Дорожная карта</a>
-      <a class="btn" href="/pages/book.html" data-i18n="nav.book">Книга Жизни</a>
-      <a class="btn" href="/pages/b2b.html" data-i18n="nav.b2b">B2B</a>
-      <a class="btn" href="/pages/eternals.html" data-i18n="nav.eternals">Вечные</a>
-      <a class="btn" href="/pages/pricing.html" data-i18n="nav.pricing" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы</a>
-      <select class="lang-switch"><option value="ru">RU</option><option value="en">EN</option></select>
-    </div>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню / Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <nav class="links" id="primaryNav" aria-label="Основная навигация">
+      <article data-lang="ru" lang="ru">
+        <div class="menu-group" aria-label="Навигация по разделам страницы">
+          <a href="../index.html#mission">Главная</a>
+          <a href="../index.html#what">Что такое</a>
+          <a href="../index.html#process">Процесс</a>
+          <a href="../index.html#ai">ИИ</a>
+          <a href="../index.html#book">Книга Жизни</a>
+          <a href="../index.html#eternals">Вечные</a>
+          <a href="../index.html#audience">Для кого</a>
+          <a href="../index.html#b2b">Бизнес</a>
+          <a href="../index.html#ethics">Этика</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+      <article data-lang="en" lang="en" hidden>
+        <div class="menu-group" aria-label="Navigate page sections">
+          <a href="../index.html#mission">Home</a>
+          <a href="../index.html#what">What</a>
+          <a href="../index.html#process">Process</a>
+          <a href="../index.html#ai">AI</a>
+          <a href="../index.html#book">Book of Life</a>
+          <a href="../index.html#eternals">Eternals</a>
+          <a href="../index.html#audience">Audience</a>
+          <a href="../index.html#b2b">Business</a>
+          <a href="../index.html#ethics">Ethics</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+    </nav>
+    <select class="lang-switch" aria-label="Switch language">
+      <option value="ru">RU</option>
+      <option value="en">EN</option>
+    </select>
   </div>
 </header>
+<div class="nav-overlay" id="navOverlay" hidden></div>
+<aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
+  <div class="nav-drawer__header">
+    <h2 id="menuTitle">
+      <span data-lang="ru" lang="ru">Меню</span>
+      <span data-lang="en" lang="en" hidden>Menu</span>
+    </h2>
+    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню / Close menu">✕</button>
+  </div>
+
+  <nav class="nav-drawer__body stack" aria-label="Навигация по сайту">
+    <article data-lang="ru" lang="ru" class="stack">
+      <div class="drawer-group stack">
+        <div class="drawer-title">Разделы</div>
+        <a href="../index.html#mission">Главная</a>
+        <a href="../index.html#what">Что такое</a>
+        <a href="../index.html#process">Процесс</a>
+        <a href="../index.html#ai">ИИ</a>
+        <a href="../index.html#book">Книга Жизни</a>
+        <a href="../index.html#eternals">Вечные</a>
+        <a href="../index.html#audience">Для кого</a>
+        <a href="../index.html#b2b">Бизнес</a>
+        <a href="../index.html#ethics">Этика</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Страницы</div>
+        <a href="pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Тарифы</a>
+        <a href="methodology.html" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Методология</a>
+        <a href="book.html" data-href-ru="book.html" data-href-en="book.html?lang=en">Издание «Книга Жизни»</a>
+        <a href="eternals.html" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Библиотека «Вечных»</a>
+        <a href="b2b.html" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">Корпоративные решения</a>
+        <a href="cases.html" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Кейсы</a>
+        <a href="team.html" data-href-ru="team.html" data-href-en="team.html?lang=en" class="active">Команда</a>
+        <a href="roadmap.html" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Роадмап</a>
+      </div>
+    </article>
+
+    <article data-lang="en" lang="en" class="stack" hidden>
+      <div class="drawer-group stack">
+        <div class="drawer-title">Sections</div>
+        <a href="../index.html#mission">Home</a>
+        <a href="../index.html#what">What</a>
+        <a href="../index.html#process">Process</a>
+        <a href="../index.html#ai">AI</a>
+        <a href="../index.html#book">Book of Life</a>
+        <a href="../index.html#eternals">Eternals</a>
+        <a href="../index.html#audience">Audience</a>
+        <a href="../index.html#b2b">Business</a>
+        <a href="../index.html#ethics">Ethics</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Pages</div>
+        <a href="../en/pages/pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Pricing</a>
+        <a href="methodology.html?lang=en" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Methodology</a>
+        <a href="book.html?lang=en" data-href-ru="book.html" data-href-en="book.html?lang=en">Book of Life</a>
+        <a href="eternals.html?lang=en" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Eternals Library</a>
+        <a href="b2b.html?lang=en" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">B2B solutions</a>
+        <a href="cases.html?lang=en" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Cases</a>
+        <a href="team.html?lang=en" data-href-ru="team.html" data-href-en="team.html?lang=en" class="active">Team</a>
+        <a href="roadmap.html?lang=en" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Roadmap</a>
+      </div>
+    </article>
+  </nav>
+  <div class="nav-drawer__footer">
+    <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
+    </a>
+    <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
+      <span data-lang="ru" lang="ru">Telegram-канал</span>
+      <span data-lang="en" lang="en" hidden>Telegram channel</span>
+    </a>
+  </div>
+</aside>
 <main>
   <article class="page-intro" data-lang="ru" lang="ru">
     <section class="section">


### PR DESCRIPTION
## Summary
- replace the navigation header on all Russian interior pages with the same responsive layout used on the home page, including the language switcher and drawer
- update the English pricing page to share the unified header markup and correct relative links for cross-language navigation

## Testing
- No automated tests were run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68dfdc8229f4832fa6806f382c615e74