### PR TITLE
Add standalone English pages and update language switching

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -1,0 +1,513 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>EVERA | Living Memory & Digital Immortality</title>
+  <!--
+    Полная версия главной страницы EVERA. Встроены дополнительные
+    блоки с текстом из редакционного документа: миссия, что такое
+    EVERA, модуль ИИ, для кого проект, корпоративные решения,
+    безопасность и этика, отзывы и расширенный FAQ. Такой объём
+    контента помогает SEO и служит основой для посадочной.
+  -->
+  <meta name="description" content="EVERA captures voices, stories, and emotions with 150+ interview questions, AI analysis, the Book of Life, and the Eternals Library.">
+  <meta property="og:title" content="EVERA | Living Memory & Digital Immortality">
+  <meta property="og:description" content="EVERA captures voices, stories, and emotions with 150+ interview questions, AI analysis, the Book of Life, and the Eternals Library.">
+  <meta property="og:image" content="/evera-logo-white.png">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://evera.world/en/">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="EVERA | Living Memory & Digital Immortality">
+  <meta name="twitter:description" content="EVERA captures voices, stories, and emotions with 150+ interview questions, AI analysis, the Book of Life, and the Eternals Library.">
+  <meta name="twitter:image" content="/evera-logo-white.png">
+  <meta name="keywords" content="digital immortality, digital legacy, Book of Life, Eternals Library, AI interviews, memory preservation">
+  <link rel="icon" href="/evera-logo-white.svg">
+  <link rel="canonical" href="https://evera.world/en/">
+  <link rel="alternate" hreflang="en" href="https://evera.world/en/">
+  <link rel="alternate" hreflang="ru" href="https://evera.world/">
+  <link rel="manifest" href="/manifest.json">
+  <link rel="stylesheet" href="/css/styles.css">
+</head>
+<body data-nebula="home">
+  <div class="read-progress" id="readProgress" aria-hidden="true"></div>
+  <!-- Туманность с наложением. Располагается под слоем звёзд. -->
+  <canvas id="nebula" data-parallax-speed="0.006" aria-hidden="true"></canvas>
+  <!-- Звёздное небо на фоне. Canvas размещён под контентом. -->
+  <canvas id="stars" aria-hidden="true"></canvas>
+  <div class="parallax-layer parallax-layer--nebula" data-parallax-speed="0.008" aria-hidden="true"></div>
+  <div class="parallax-layer parallax-layer--dust" data-parallax-speed="0.012" aria-hidden="true"></div>
+  <div class="parallax-layer parallax-layer--sparks" data-parallax-speed="0.016" aria-hidden="true"></div>
+
+  <!-- Шапка сайта: логотип и навигация по секциям -->
+  <header class="header">
+    <div class="nav container">
+      <a class="logo" href="#mission" aria-label="EVERA">
+        <img src="/evera-logo-white.svg" alt="EVERA logo">
+      </a>
+      <button id="menuToggle" class="menu-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+      <nav class="links" id="primaryNav" aria-label="Primary navigation">
+        
+        <article lang="en">
+          <div class="menu-group" aria-label="Navigate page sections">
+            <a href="#mission" class="active">Home</a>
+            <a href="#what">What</a>
+            <a href="#process">Process</a>
+            <a href="#ai">AI</a>
+            <a href="#book">Book of Life</a>
+            <a href="#eternals">Eternals</a>
+            <a href="#audience">Audience</a>
+            <a href="#b2b">Business</a>
+            <a href="#ethics">Ethics</a>
+            <a href="#faq">FAQ</a>
+          </div>
+        </article>
+      </nav>
+      <select class="lang-switch" aria-label="Switch language">
+        <option value="ru" data-url="/index.html">RU</option>
+        <option value="en" data-url="/en/index.html" selected>EN</option>
+      </select>
+    </div>
+  </header>
+
+  <div class="nav-overlay" id="navOverlay" hidden></div>
+  <aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
+    <div class="nav-drawer__header">
+      <h2 id="menuTitle">
+        
+        <span lang="en">Menu</span>
+      </h2>
+      <button class="nav-drawer__close" id="navClose" aria-label="Close menu">✕</button>
+    </div>
+
+    <nav class="nav-drawer__body stack" aria-label="Site navigation">
+      
+
+      <article lang="en" class="stack">
+        <div class="drawer-group stack">
+          <div class="drawer-title">Sections</div>
+          <a href="#mission">Home</a>
+          <a href="#what">What</a>
+          <a href="#process">Process</a>
+          <a href="#ai">AI</a>
+          <a href="#book">Book of Life</a>
+          <a href="#eternals">Eternals</a>
+          <a href="#audience">Audience</a>
+          <a href="#b2b">Business</a>
+          <a href="#ethics">Ethics</a>
+          <a href="#faq">FAQ</a>
+        </div>
+
+        <div class="drawer-group stack">
+          <div class="drawer-title">Pages</div>
+          <a href="pages/pricing.html">Pricing</a>
+          <a href="pages/methodology.html">Methodology</a>
+          <a href="pages/book.html">Book of Life</a>
+          <a href="pages/eternals.html">Eternals Library</a>
+          <a href="pages/b2b.html">B2B solutions</a>
+          <a href="pages/cases.html">Cases</a>
+          <a href="pages/team.html">Team</a>
+          <a href="pages/roadmap.html">Roadmap</a>
+        </div>
+      </article>
+    </nav>
+    <div class="nav-drawer__footer">
+      <a class="drawer-brand" href="#mission" aria-label="EVERA">
+        <img src="/evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
+      </a>
+      <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
+        
+        <span lang="en">Telegram channel</span>
+      </a>
+    </div>
+  </aside>
+
+  <main>
+    <!-- Hero/mission: короткий призыв и основная идея -->
+    <section id="mission" class="hero section">
+      
+      <article lang="en">
+        <div class="container reveal stack" data-parallax-speed="0.01">
+          <div class="overlay stack">
+            <h1>EVERA<br>Living memory<br>Portal to eternity</h1>
+            <p class="lead">
+              We preserve voices, stories, and values so descendants can speak with you across decades.
+              150+ interview prompts, speech analytics, and the Book of Life turn memory into a living dialogue.
+            </p>
+            <div class="cta stack">
+              <a class="btn" href="#process">See how it works</a>
+              <a class="btn ghost" href="https://t.me/sololabschannel" target="_blank" rel="noopener">Telegram channel</a>
+            </div>
+            <div class="stat-grid reveal-stagger">
+              <div class="stat"><b>150+</b>deep-dive interview prompts</div>
+              <div class="stat"><b>1&nbsp;M+</b>words — minimum data set</div>
+              <div class="stat"><b>24/7</b>access to the digital portrait</div>
+              <div class="stat"><b>100%</b>privacy and access control</div>
+              <div class="stat"><b>20+</b>emotional and semantic metrics</div>
+              <div class="stat">Book of Life edition based on biography</div>
+            </div>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <!-- Миссия и польза -->
+    <section id="overview" class="section">
+      
+      <article lang="en">
+        <div class="container reveal stack">
+          <h2>EVERA mission</h2>
+          <p>EVERA is a space where voices never fade. We carefully transform memories, speech, values, and personal
+            stories into a digital portrait that descendants, students, and researchers can converse with. It is not
+            a cold archive or questionnaire — it is a living dialogue across time.</p>
+          <p>You preserve what must not be lost: intonations, signature phrases, biographical facts, and emotional
+            emphasis. The result is a digitised legacy that remains available to the family — and, if you wish, to the
+            world.</p>
+        </div>
+      </article>
+    </section>
+
+    <!-- Что такое EVERA -->
+    <section id="what" class="section">
+      
+      <article lang="en">
+        <div class="container reveal stack">
+          <h2>What is EVERA?</h2>
+          <p>EVERA is a method and platform for creating digital immortality in the language of your family and culture.
+            We gather audio and video interviews, letters, and photos, build a biographical timeline, and capture
+            lexical style and emotional markers. These sources form a digital portrait able to sustain themed
+            conversations.</p>
+          <p>Unlike impersonal archives or rigid surveys, EVERA enables dialogue: ask about childhood, principles,
+            decisive moments, or family history and receive answers grounded in real speech, semantic clusters, and
+            verified facts. It is a digitised personality that respects context and boundaries.</p>
+        </div>
+      </article>
+    </section>
+
+    <!-- Процесс: 3 шага. Используются блоки step. -->
+    <section id="process" class="section">
+      
+      <article lang="en">
+        <div class="container reveal stack">
+          <div class="kicker">Process</div>
+          <h2>How it works</h2>
+          <p class="sub">Interview → Analytics → Dialogue. Respectful, transparent, without mysticism.</p>
+          <div class="process reveal-stagger">
+            <div class="step">
+              <div class="step-icon">
+                <img src="/assets/icons/interview.svg" alt="" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Ccircle%20cx%3D%2212%22%20cy%3D%229%22%20r%3D%224%22/%3E%3Cpath%20d%3D%22M8%2015c0%202.209%201.791%204%204%204s4-1.791%204-4%22/%3E%3Cpath%20d%3D%22M5%205l2.5%202.5M19%205l-2.5%202.5%22/%3E%3C/svg%3E';">
+              </div>
+              <div class="step-content">
+                <b>Interviews: 150+ prompts</b><br>
+                Childhood, family, genealogy, education, work, passions, ethical choices, and philosophy. Sessions are
+                flexible — remote or on-site, one-to-one or with relatives. The script adapts to reveal sensory
+                details, speech habits, and signature turns of phrase.
+              </div>
+            </div>
+            <div class="step">
+              <div class="step-icon">
+                <img src="/assets/icons/analysis.svg" alt="" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22M4%2015l4-4%203%203%205-5%204%204%22/%3E%3Cpath%20d%3D%22M4%204h16v16H4z%22/%3E%3C/svg%3E';">
+              </div>
+              <div class="step-content">
+                <b>Analytics: lexicon, emotion, structure</b><br>
+                Audio is transcribed, segmented, and cleaned. Stories are clustered, episodes and characters are
+                tagged, lexical profiles and emotional tones are highlighted. A memory graph emerges: a map of plots,
+                people, places, and motives.
+              </div>
+            </div>
+            <div class="step">
+              <div class="step-icon">
+                <img src="/assets/icons/dialog.svg" alt="" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22M5%205h14v8H9l-4%204z%22/%3E%3Cpath%20d%3D%22M9%2015v4l4-4h6v4l-4%204v-4H9z%22/%3E%3C/svg%3E';">
+              </div>
+              <div class="step-content">
+                <b>Dialogue layer: voice, style, access</b><br>
+                A cognitive model shapes a virtual companion who replies in the original cadence, cites sources, and
+                clarifies origins. Access can be configured from a private family circle to the public Eternals Library.
+              </div>
+            </div>
+          </div>
+          <div class="section-cta">
+            <a class="btn ghost" href="pages/methodology.html">Discover the methodology</a>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <!-- ИИ модуль -->
+    <section id="ai" class="section">
+      
+      <article lang="en">
+        <div class="container reveal stack">
+          <div class="kicker">AI</div>
+          <h2>AI “Architect of Eternity”</h2>
+          <p>Our custom AI module highlights episodes, builds a narrative map, finds lexical patterns, tracks emotional
+            dynamics, and helps structure the Book of Life. It never invents facts — it works strictly with verified
+            sources: interviews, documents, and artefacts. An expert editorial layer supervises the model: identity
+            verification, ambiguity editing, and ethical safeguards.</p>
+        </div>
+      </article>
+    </section>
+
+    <!-- Книга Жизни -->
+    <section id="book" class="section">
+      
+      <article lang="en">
+        <div class="container reveal stack">
+          <div class="kicker">Edition</div>
+          <h2>Book of Life</h2>
+          <p>The Book of Life is a crafted biographical chronicle: era-based chapters, themes, quotes, photography,
+            timelines, and QR codes leading to audio and video fragments. The edition can be printed, an interactive
+            PDF, or a web volume with advanced search and navigation. Editors assemble the vocal portrait with care so
+            signature words and intonations guide the meaning.</p>
+          <div class="section-cta">
+            <a class="btn ghost" href="pages/book.html">Learn about the Book of Life</a>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <!-- Библиотека Вечных -->
+    <section id="eternals" class="section">
+      
+      <article lang="en">
+        <div class="container reveal stack">
+          <div class="kicker">Education</div>
+          <h2>Eternals Library</h2>
+          <p>The Eternals Library is a collection of public digital portraits of historical figures, patrons,
+            scientists, educators, and cultural leaders. It enables ethical educational dialogues: style is restored,
+            sources are cited, and reconstruction limits are highlighted. Teachers use the library as an interactive
+            textbook; families and foundations use it as a memorial AI archive for exhibitions, audio tours, and
+            themed gatherings.</p>
+          <div class="section-cta">
+            <a class="btn ghost" href="pages/eternals.html">Visit the Eternals Library</a>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <!-- Для кого -->
+    <section id="audience" class="section">
+      
+      <article lang="en">
+        <div class="container reveal stack">
+          <div class="kicker">Audience</div>
+          <h2>Who it is for</h2>
+          <p><strong>Families</strong> receive a digital legacy that unites generations: children hear familiar
+            intonations, learn family recipes and principles, and comprehend their heritage.</p>
+          <p><strong>Museums, archives, and educational projects</strong> create interactive cases: audio guides,
+            exhibitions, history and literature lessons, dialogues with sources.</p>
+          <p><strong>Researchers</strong> gain structured datasets for history, ethnography, linguistics, and psychology
+            projects. EVERA provides verified facts and emotional profiles.</p>
+        </div>
+      </article>
+    </section>
+
+    <!-- Корпоративный блок -->
+    <section id="b2b" class="section">
+      
+      <article lang="en">
+        <div class="container reveal stack">
+          <div class="kicker">Corporate</div>
+          <h2>EVERA for business</h2>
+          <p>Corporate memory that actually works. EVERA helps companies create a digital brand presence and digitise
+            leaders: voice, values, management principles, decision cases. It is not a PR bot but a verifiable
+            cognitive knowledge base accessible to employees, partners, and media under clear rules.</p>
+          <ul class="business-list reveal-stagger">
+            <li><strong>Unified brand voice</strong>: consistent answers and tone for the website, press kit, and service scenarios.</li>
+            <li><strong>Operational knowledge</strong>: conversational access to cases, playbooks, product history, and sales narratives.</li>
+            <li><strong>Succession of leadership</strong>: transfer management approaches and principles to new teams.</li>
+            <li><strong>Onboarding</strong>: immerse newcomers quickly through dialogues with company and leadership portraits.</li>
+            <li><strong>CSR and employer brand</strong>: public editions for careers, educational partnerships, and media.</li>
+          </ul>
+          <div class="cta-block">
+            <p>Explore EVERA plans or request a tailored quote — the team replies via email or Telegram.</p>
+            <div class="cta-actions">
+              <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20-%20Request%20a%20quote">Request a quote</a>
+              <a class="btn" href="pages/pricing.html">View all plans</a>
+              <a class="btn ghost" href="https://t.me/Solo013" target="_blank" rel="noopener">Telegram</a>
+            </div>
+            <div class="section-cta">
+              <a class="btn ghost" href="pages/b2b.html">Learn about B2B solutions</a>
+            </div>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <!-- Бзопасность и этика -->
+    <section id="ethics" class="section">
+      
+      <article lang="en">
+        <div class="container reveal stack">
+          <div class="kicker">Ethics</div>
+          <h2>Security and ethics</h2>
+          <p><strong>Data treated as sacred.</strong> All personal data is encrypted; access is configured via family roles
+            (family admin, editor, reader). We record family consent, document transparent data use, host it on reliable
+            infrastructure, and provide flexible access tiers.</p>
+          <p><strong>Ethical principles.</strong> Respect for memory and personal autonomy, transparency of methods,
+            a clear separation of facts from interpretations, and labelling of reconstructed fragments. Sensitive
+            topics are handled with caution and the family’s wishes take priority.</p>
+        </div>
+      </article>
+    </section>
+
+    <!-- Отзывы -->
+    <section id="reviews" class="section">
+      
+      <article lang="en">
+        <div class="container reveal stack">
+          <div class="kicker">Testimonials</div>
+          <h2>Testimonials</h2>
+          <div class="reviews-grid reveal-stagger">
+            <div class="review">
+              “We heard our grandfather again. His favourite expressions and pauses — as if we were back in the kitchen together.” — Maria K.
+            </div>
+            <div class="review">
+              “For a school project we interviewed the portrait of our teacher and unpacked his decisions from the toughest years.” — Pavel N.
+            </div>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <!-- FAQ -->
+    <section id="faq" class="section">
+      
+      <article lang="en">
+        <div class="container reveal stack">
+          <div class="kicker">FAQ</div>
+          <h2>Frequently asked questions</h2>
+          <details open>
+            <summary>What is digital immortality?</summary>
+            <p>It is the digitisation of a personality — not only facts but also speech, values, and emotional cues so
+              descendants can converse with their ancestors safely and ethically.</p>
+          </details>
+          <details>
+            <summary>How is the digital portrait created?</summary>
+            <p>Interviews (150+ prompts) → analytics (lexicon, emotions, clusters) → cognitive model →
+              virtual companion with configurable access.</p>
+          </details>
+          <details>
+            <summary>Can we digitise my parents’ memories?</summary>
+            <p>Yes. We help prepare questions, gather materials, run interviews, and configure family access.</p>
+          </details>
+          <details>
+            <summary>How is EVERA different from chatbots?</summary>
+            <p>It is grounded in real speech and biography with verification, source citations, and ethical filters. No
+              “made up” responses without clear labelling.</p>
+          </details>
+          <details>
+            <summary>How are my data protected?</summary>
+            <p>Encryption, family-controlled consent, secure infrastructure, an access broker, and an audit log.</p>
+          </details>
+          <details>
+            <summary>How long does the process take?</summary>
+            <p>First results appear right after interviews — a portrait preview and digest. The full Book of Life and
+              dialogue layer follow the agreed roadmap.</p>
+          </details>
+        </div>
+      </article>
+    </section>
+
+    <!-- Финальный шаг и кнопка создания -->
+    <section id="final" class="section">
+      
+      <article lang="en">
+        <div class="container reveal stack">
+          <h2>Ready to preserve memory?</h2>
+          <p>EVERA keeps what usually slips away: voice, meaning, connection. Create a digital legacy that remains
+            accessible and comprehensible for future generations.</p>
+          <div class="cta stack">
+            <a class="btn" href="#" data-dialog-target="donateDialog">Support the project</a>
+            <a class="btn ghost" href="https://t.me/sololabschannel" target="_blank" rel="noopener">Schedule an interview</a>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <!-- Donation modal (общий для всего сайта) -->
+    <dialog id="donateDialog">
+      
+      <article lang="en">
+        <h3>Support EVERA</h3>
+        <p class="small">Choose a network and copy the address for your donation.</p>
+      </article>
+      <label>
+        
+        <span lang="en">Network:</span>
+        <select id="donNetwork">
+          <option value="usdt">USDT TRC20</option>
+          <option value="ton">Toncoin (TON)</option>
+          <option value="btc">Bitcoin (BTC)</option>
+          <option value="eth">Ethereum (ETH)</option>
+        </select>
+      </label>
+      <label>
+        
+        <span lang="en">Address:</span>
+        <input type="text" id="donAddress" readonly>
+      </label>
+      <div class="modal-actions">
+        <button id="copyAddr" class="btn ghost" type="button">
+          
+          <span lang="en">Copy</span>
+        </button>
+        <button id="closeDonate" class="btn" type="button">
+          
+          <span lang="en">Close</span>
+        </button>
+      </div>
+    </dialog>
+  </main>
+
+  <!-- Подвал -->
+  <footer class="footer">
+    
+    <article lang="en">
+      <div class="container">
+        <div class="footer-grid">
+          <div class="footer-brand">
+            <a class="logo" href="#mission" aria-label="EVERA"><img src="/evera-logo-white.svg" alt="EVERA"></a>
+            <p class="small">EVERA — digital immortality and a living dialogue across generations.</p>
+            <p class="small">Contact: <a href="mailto:hello@evera.world">hello@evera.world</a><br><a href="https://t.me/Solo013" target="_blank" rel="noopener">t.me/Solo013</a></p>
+          </div>
+          <div class="footer-col">
+            <h3>Navigation</h3>
+            <ul>
+              <li><a href="#what">What is EVERA</a></li>
+              <li><a href="#process">Methodology</a></li>
+              <li><a href="#book">Book of Life</a></li>
+              <li><a href="#eternals">Eternals Library</a></li>
+              <li><a href="#b2b">Business solutions</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h3>Pages</h3>
+            <ul>
+              <li><a href="pages/methodology.html">Methodology</a></li>
+              <li><a href="pages/book.html">Book of Life</a></li>
+              <li><a href="pages/eternals.html">Eternals Library</a></li>
+              <li><a href="pages/b2b.html">B2B solutions</a></li>
+              <li><a href="pages/pricing.html">All plans</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h3>Resources</h3>
+            <ul>
+              <li><a href="/sitemap.xml">Sitemap</a></li>
+              <li><a href="/robots.txt">robots.txt</a></li>
+              <li><a href="pages/team.html">Team</a></li>
+              <li><a href="pages/roadmap.html">Roadmap</a></li>
+              <li><a href="pages/cases.html">Cases</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="copy">© 2025 EVERA · No ads · No trackers</div>
+      </div>
+    </article>
+  </footer>
+
+  <!-- Главный скрипт: звёзды, модальное окно, reveal-анимации -->
+  <script src="/js/app.js"></script>
+</body>
+</html>

--- a/en/pages/b2b.html
+++ b/en/pages/b2b.html
@@ -1,0 +1,209 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>EVERA for Business | Corporate memory & founder storytelling</title>
+<meta name="description" content="Bring EVERA to your organisation to preserve founder voices, brand heritage, internal knowledge, and learning programs with conversational AI.">
+<meta property="og:title" content="EVERA for Business | Corporate memory & founder storytelling">
+<meta property="og:description" content="Bring EVERA to your organisation to preserve founder voices, brand heritage, internal knowledge, and learning programs with conversational AI.">
+<meta property="og:image" content="/evera-logo-white.png">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://evera.world/en/b2b">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="EVERA for Business | Corporate memory & founder storytelling">
+<meta name="twitter:description" content="Bring EVERA to your organisation to preserve founder voices, brand heritage, internal knowledge, and learning programs with conversational AI.">
+<meta name="twitter:image" content="/evera-logo-white.png">
+  <link rel="icon" href="/assets/icons/favicon.svg">
+<link rel="alternate" hreflang="en" href="https://evera.world/en/b2b">
+<link rel="alternate" hreflang="ru" href="https://evera.world/b2b">
+<link rel="canonical" href="https://evera.world/en/b2b">
+<link rel="stylesheet" href="/css/styles.css">
+</head>
+<body data-nebula="b2b">
+<div class="read-progress" id="readProgress" aria-hidden="true"></div>
+<canvas id="nebula" aria-hidden="true"></canvas>
+<canvas id="stars" aria-hidden="true"></canvas>
+<header class="header">
+  <div class="nav container">
+    <a class="logo" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA logo">
+    </a>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <nav class="links" id="primaryNav" aria-label="Primary navigation">
+      
+      <article lang="en">
+        <div class="menu-group" aria-label="Navigate page sections">
+          <a href="../index.html#mission">Home</a>
+          <a href="../index.html#what">What</a>
+          <a href="../index.html#process">Process</a>
+          <a href="../index.html#ai">AI</a>
+          <a href="../index.html#book">Book of Life</a>
+          <a href="../index.html#eternals">Eternals</a>
+          <a href="../index.html#audience">Audience</a>
+          <a href="../index.html#b2b">Business</a>
+          <a href="../index.html#ethics">Ethics</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+    </nav>
+    <select class="lang-switch" aria-label="Switch language">
+      <option value="ru" data-url="/pages/b2b.html">RU</option>
+      <option value="en" data-url="/en/pages/b2b.html" selected>EN</option>
+    </select>
+  </div>
+</header>
+<div class="nav-overlay" id="navOverlay" hidden></div>
+<aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
+  <div class="nav-drawer__header">
+    <h2 id="menuTitle">
+      
+      <span lang="en">Menu</span>
+    </h2>
+    <button class="nav-drawer__close" id="navClose" aria-label="Close menu">✕</button>
+  </div>
+
+  <nav class="nav-drawer__body stack" aria-label="Site navigation">
+    
+
+    <article lang="en" class="stack">
+      <div class="drawer-group stack">
+        <div class="drawer-title">Sections</div>
+        <a href="../index.html#mission">Home</a>
+        <a href="../index.html#what">What</a>
+        <a href="../index.html#process">Process</a>
+        <a href="../index.html#ai">AI</a>
+        <a href="../index.html#book">Book of Life</a>
+        <a href="../index.html#eternals">Eternals</a>
+        <a href="../index.html#audience">Audience</a>
+        <a href="../index.html#b2b">Business</a>
+        <a href="../index.html#ethics">Ethics</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Pages</div>
+        <a href="pricing.html">Pricing</a>
+        <a href="methodology.html">Methodology</a>
+        <a href="book.html">Book of Life</a>
+        <a href="eternals.html">Eternals Library</a>
+        <a href="b2b.html" class="active">B2B solutions</a>
+        <a href="cases.html">Cases</a>
+        <a href="team.html">Team</a>
+        <a href="roadmap.html">Roadmap</a>
+      </div>
+    </article>
+  </nav>
+  <div class="nav-drawer__footer">
+    <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
+    </a>
+    <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
+      
+      <span lang="en">Telegram channel</span>
+    </a>
+  </div>
+</aside>
+<main>
+  
+  <article class="page-intro" lang="en">
+    <section class="section">
+      <div class="container">
+        <h1>EVERA for Business</h1>
+        <p class="lead">We build corporate memory: the founder’s voice, case library, onboarding scenarios, and PR support. Your brand receives a conversational partner that speaks in your company’s tone.</p>
+        <div class="pill-list"><span>Legacy</span><span>Learning</span><span>PR</span><span>Investors</span></div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Use cases</div>
+        <h2>Business challenges we solve</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Onboarding</h3>
+            <p>New hires explore company history, values, and landmark decisions through dialogue and real stories.</p>
+          </div>
+          <div class="card">
+            <h3>Public communications</h3>
+            <p>A consistent brand voice for media, partners, and conferences with answers backed by verified sources.</p>
+          </div>
+          <div class="card">
+            <h3>Investor relations</h3>
+            <p>Instant responses about product economics, strategy, and leadership principles.</p>
+          </div>
+          <div class="card">
+            <h3>Leadership legacy</h3>
+            <p>Preserves founders’ philosophy and management practices as part of the corporate university.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Modules</div>
+        <h2>Product configuration</h2>
+        <div class="two-column">
+          <div>
+            <h3>Brand dialogue AI</h3>
+            <p>The trained model speaks with the leadership voice, cites documents, and logs user feedback automatically.</p>
+            <ul>
+              <li>Modes: PR, HR, Investors.</li>
+              <li>Integrations with Slack, Teams, and internal portals.</li>
+            </ul>
+          </div>
+          <div>
+            <h3>Decision archive</h3>
+            <p>Structured cases and regulations available via search and thematic maps.</p>
+            <ul>
+              <li>Dedicated views for employees and authorised partners.</li>
+              <li>Automatic updates after every new interview cycle.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Implementation</div>
+        <h2>Launch phases</h2>
+        <ul class="timeline">
+          <li><strong>Diagnosis.</strong> Align goals, KPIs, and team composition.</li>
+          <li><strong>Interviews &amp; data.</strong> In-depth interviews with founders and key teams plus content audit.</li>
+          <li><strong>Knowledge base.</strong> Analytics, structuring, and access configuration.</li>
+          <li><strong>Go-live &amp; training.</strong> Pilot sessions, employee workshops, and feedback loop.</li>
+          <li><strong>Support.</strong> Quarterly updates, quality assurance, and scenario expansion.</li>
+        </ul>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Plans</div>
+        <h2>Partnership packages</h2>
+        <div class="table-like">
+          <div class="row">
+            <h3>Start</h3>
+            <p>One key leader, three interviews, core dialogue module, six-week launch.</p>
+          </div>
+          <div class="row">
+            <h3>Scale</h3>
+            <p>Three to five leaders, corporate decision archive, HR system integration, six-month support.</p>
+          </div>
+          <div class="row">
+            <h3>Enterprise</h3>
+            <p>Multi-office deployment, SLA, custom scenarios, and in-house curator training.</p>
+          </div>
+        </div>
+        <div class="cta-block">
+          <p>Explore EVERA pricing or reach out for a bespoke scope tailored to your organisation.</p>
+          <div class="cta-actions">
+            <a class="btn" href="mailto:b2b@evera.world?subject=EVERA%20B2B%20-%20Request%20a%20quote">Request a quote</a>
+            <a class="btn" href="/en/pages/pricing.html">EVERA Pricing</a>
+            <a class="btn ghost" href="https://t.me/Solo013" target="_blank" rel="noopener">Telegram</a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </article>
+</main>
+<footer class="footer"><div class="small">© 2025 EVERA</div></footer>
+<script src="/js/app.js"></script>
+</body></html>

--- a/en/pages/book.html
+++ b/en/pages/book.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Book of Life by EVERA | Personalized memory edition</title>
+<meta name="description" content="Discover the Book of Life: curated stories, photos, and AI narratives that preserve family history in collectible print and digital formats.">
+<meta property="og:title" content="Book of Life by EVERA | Personalized memory edition">
+<meta property="og:description" content="Discover the Book of Life: curated stories, photos, and AI narratives that preserve family history in collectible print and digital formats.">
+<meta property="og:image" content="/evera-logo-white.png">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://evera.world/en/book">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Book of Life by EVERA | Personalized memory edition">
+<meta name="twitter:description" content="Discover the Book of Life: curated stories, photos, and AI narratives that preserve family history in collectible print and digital formats.">
+<meta name="twitter:image" content="/evera-logo-white.png">
+  <link rel="icon" href="/assets/icons/favicon.svg">
+<link rel="alternate" hreflang="en" href="https://evera.world/en/book">
+<link rel="alternate" hreflang="ru" href="https://evera.world/book">
+<link rel="canonical" href="https://evera.world/en/book">
+<link rel="stylesheet" href="/css/styles.css">
+</head>
+<body data-nebula="book">
+<div class="read-progress" id="readProgress" aria-hidden="true"></div>
+<canvas id="nebula" aria-hidden="true"></canvas>
+<canvas id="stars" aria-hidden="true"></canvas>
+<header class="header">
+  <div class="nav container">
+    <a class="logo" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA logo">
+    </a>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <nav class="links" id="primaryNav" aria-label="Primary navigation">
+      
+      <article lang="en">
+        <div class="menu-group" aria-label="Navigate page sections">
+          <a href="../index.html#mission">Home</a>
+          <a href="../index.html#what">What</a>
+          <a href="../index.html#process">Process</a>
+          <a href="../index.html#ai">AI</a>
+          <a href="../index.html#book">Book of Life</a>
+          <a href="../index.html#eternals">Eternals</a>
+          <a href="../index.html#audience">Audience</a>
+          <a href="../index.html#b2b">Business</a>
+          <a href="../index.html#ethics">Ethics</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+    </nav>
+    <select class="lang-switch" aria-label="Switch language">
+      <option value="ru" data-url="/pages/book.html">RU</option>
+      <option value="en" data-url="/en/pages/book.html" selected>EN</option>
+    </select>
+  </div>
+</header>
+<div class="nav-overlay" id="navOverlay" hidden></div>
+<aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
+  <div class="nav-drawer__header">
+    <h2 id="menuTitle">
+      
+      <span lang="en">Menu</span>
+    </h2>
+    <button class="nav-drawer__close" id="navClose" aria-label="Close menu">✕</button>
+  </div>
+
+  <nav class="nav-drawer__body stack" aria-label="Site navigation">
+    
+
+    <article lang="en" class="stack">
+      <div class="drawer-group stack">
+        <div class="drawer-title">Sections</div>
+        <a href="../index.html#mission">Home</a>
+        <a href="../index.html#what">What</a>
+        <a href="../index.html#process">Process</a>
+        <a href="../index.html#ai">AI</a>
+        <a href="../index.html#book">Book of Life</a>
+        <a href="../index.html#eternals">Eternals</a>
+        <a href="../index.html#audience">Audience</a>
+        <a href="../index.html#b2b">Business</a>
+        <a href="../index.html#ethics">Ethics</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Pages</div>
+        <a href="pricing.html">Pricing</a>
+        <a href="methodology.html">Methodology</a>
+        <a href="book.html" class="active">Book of Life</a>
+        <a href="eternals.html">Eternals Library</a>
+        <a href="b2b.html">B2B solutions</a>
+        <a href="cases.html">Cases</a>
+        <a href="team.html">Team</a>
+        <a href="roadmap.html">Roadmap</a>
+      </div>
+    </article>
+  </nav>
+  <div class="nav-drawer__footer">
+    <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
+    </a>
+    <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
+      
+      <span lang="en">Telegram channel</span>
+    </a>
+  </div>
+</aside>
+<main>
+  
+  <article class="page-intro" lang="en">
+    <section class="section">
+      <div class="container">
+        <h1>EVERA Book of Life</h1>
+        <p class="lead">A signature edition that combines biographical chapters, quotations, photographs, and audio fragments. It is more than a family chronicle - it is a navigation system for memory.</p>
+        <div class="pill-list"><span>Voices</span><span>Photo archive</span><span>Quotes</span><span>QR links</span></div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Highlights</div>
+        <h2>What the edition includes</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Structure &amp; chapters</h3>
+            <p>The story unfolds by eras: childhood, turning points, legacy. Each chapter closes with insights and key values.</p>
+          </div>
+          <div class="card">
+            <h3>Voices &amp; emotions</h3>
+            <p>QR codes lead to audio and video. Loved ones hear the intonation, pauses, and laughter that text alone cannot carry.</p>
+          </div>
+          <div class="card">
+            <h3>Visual narrative</h3>
+            <p>We digitise photos, letters, and documents. Designers create collages, maps, and family trees.</p>
+          </div>
+          <div class="card">
+            <h3>Meaningful navigation</h3>
+            <p>Cross-links guide the reader to themes such as “Teaching”, “Travel”, “Family values”. Every story has a context.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Process</div>
+        <h2>How we craft the book</h2>
+        <ul class="timeline">
+          <li><strong>Gathering materials.</strong> Interviews, archives, letters. A curator helps prioritise stories.</li>
+          <li><strong>Editorial scripting.</strong> The editor shapes chapters, builds dramaturgy, and selects quotations.</li>
+          <li><strong>Design &amp; layout.</strong> Visual concept with palette, typography, and bespoke illustrations.</li>
+          <li><strong>Prototype review.</strong> The family receives a digital mockup, comments, and approves changes.</li>
+          <li><strong>Print &amp; digital delivery.</strong> Premium print run, interactive PDF, and upload to the family portal.</li>
+        </ul>
+        <p class="quote">“The Book of Life reminds us why our family exists. It’s not an album, it’s a living dialogue.” - Natalia, EVERA client.</p>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Formats</div>
+        <h2>Edition options</h2>
+        <div class="table-like">
+          <div class="row">
+            <h3>Premium print</h3>
+            <p>Hardcover, silk ribbon, art paper. Delivered in a gift box with QR companion cards.</p>
+          </div>
+          <div class="row">
+            <h3>Interactive PDF</h3>
+            <p>Hyperlinked edition with embedded audio players and family-friendly commenting.</p>
+          </div>
+          <div class="row">
+            <h3>Web edition</h3>
+            <p>Private website with thematic search, extended gallery, and dialogue AI integration.</p>
+          </div>
+        </div>
+        <div class="cta-block">
+          <p>Tell us who will receive the Book of Life and we will recommend the best format and prepare a demo excerpt.</p>
+          <a class="btn" href="mailto:book@evera.world">Request a consultation</a>
+        </div>
+      </div>
+    </section>
+  </article>
+</main>
+<footer class="footer"><div class="small">© 2025 EVERA</div></footer>
+<script src="/js/app.js"></script>
+</body></html>

--- a/en/pages/cases.html
+++ b/en/pages/cases.html
@@ -1,0 +1,179 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>EVERA Case Studies | Families, brands & communities</title>
+<meta name="description" content="See how families, artists, and companies use EVERA interviews, AI synthesis, and the Book of Life to safeguard memory and pass on values.">
+<meta property="og:title" content="EVERA Case Studies | Families, brands & communities">
+<meta property="og:description" content="See how families, artists, and companies use EVERA interviews, AI synthesis, and the Book of Life to safeguard memory and pass on values.">
+<meta property="og:image" content="/evera-logo-white.png">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://evera.world/en/cases">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="EVERA Case Studies | Families, brands & communities">
+<meta name="twitter:description" content="See how families, artists, and companies use EVERA interviews, AI synthesis, and the Book of Life to safeguard memory and pass on values.">
+<meta name="twitter:image" content="/evera-logo-white.png">
+  <link rel="icon" href="/assets/icons/favicon.svg">
+<link rel="alternate" hreflang="en" href="https://evera.world/en/cases">
+<link rel="alternate" hreflang="ru" href="https://evera.world/cases">
+<link rel="canonical" href="https://evera.world/en/cases">
+<link rel="stylesheet" href="/css/styles.css">
+</head>
+<body data-nebula="cases">
+<div class="read-progress" id="readProgress" aria-hidden="true"></div>
+<canvas id="nebula" aria-hidden="true"></canvas>
+<canvas id="stars" aria-hidden="true"></canvas>
+<header class="header">
+  <div class="nav container">
+    <a class="logo" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA logo">
+    </a>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <nav class="links" id="primaryNav" aria-label="Primary navigation">
+      
+      <article lang="en">
+        <div class="menu-group" aria-label="Navigate page sections">
+          <a href="../index.html#mission">Home</a>
+          <a href="../index.html#what">What</a>
+          <a href="../index.html#process">Process</a>
+          <a href="../index.html#ai">AI</a>
+          <a href="../index.html#book">Book of Life</a>
+          <a href="../index.html#eternals">Eternals</a>
+          <a href="../index.html#audience">Audience</a>
+          <a href="../index.html#b2b">Business</a>
+          <a href="../index.html#ethics">Ethics</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+    </nav>
+    <select class="lang-switch" aria-label="Switch language">
+      <option value="ru" data-url="/pages/cases.html">RU</option>
+      <option value="en" data-url="/en/pages/cases.html" selected>EN</option>
+    </select>
+  </div>
+</header>
+<div class="nav-overlay" id="navOverlay" hidden></div>
+<aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
+  <div class="nav-drawer__header">
+    <h2 id="menuTitle">
+      
+      <span lang="en">Menu</span>
+    </h2>
+    <button class="nav-drawer__close" id="navClose" aria-label="Close menu">✕</button>
+  </div>
+
+  <nav class="nav-drawer__body stack" aria-label="Site navigation">
+    
+
+    <article lang="en" class="stack">
+      <div class="drawer-group stack">
+        <div class="drawer-title">Sections</div>
+        <a href="../index.html#mission">Home</a>
+        <a href="../index.html#what">What</a>
+        <a href="../index.html#process">Process</a>
+        <a href="../index.html#ai">AI</a>
+        <a href="../index.html#book">Book of Life</a>
+        <a href="../index.html#eternals">Eternals</a>
+        <a href="../index.html#audience">Audience</a>
+        <a href="../index.html#b2b">Business</a>
+        <a href="../index.html#ethics">Ethics</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Pages</div>
+        <a href="pricing.html">Pricing</a>
+        <a href="methodology.html">Methodology</a>
+        <a href="book.html">Book of Life</a>
+        <a href="eternals.html">Eternals Library</a>
+        <a href="b2b.html">B2B solutions</a>
+        <a href="cases.html" class="active">Cases</a>
+        <a href="team.html">Team</a>
+        <a href="roadmap.html">Roadmap</a>
+      </div>
+    </article>
+  </nav>
+  <div class="nav-drawer__footer">
+    <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
+    </a>
+    <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
+      
+      <span lang="en">Telegram channel</span>
+    </a>
+  </div>
+</aside>
+<main>
+  
+  <article class="page-intro" lang="en">
+    <section class="section">
+      <div class="container">
+        <h1>EVERA Case Studies</h1>
+        <p class="lead">We turn family archives, museum collections, and corporate knowledge into living dialogue experiences. Explore how the EVERA methodology adapts to different audiences.</p>
+        <div class="pill-list">
+          <span>Families</span><span>Museums</span><span>Education</span><span>Business</span>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Family heritage</div>
+        <h2>Portrait “The M. Family Voice”</h2>
+        <div class="two-column">
+          <div>
+            <p>A four-generation family from Saint Petersburg shared cassette tapes from the 1980s, letters, and a photo chronicle. We recorded fresh interviews, restored the vocal palette, and produced an interactive Book of Life with QR access to memories.</p>
+            <p class="quote">“Our kids hear their great-grandmother’s intonation. They don’t just read - they talk to her.” - project curator.</p>
+          </div>
+          <div class="stat-grid">
+            <div class="stat"><b>47</b>hours of interviews and transcripts</div>
+            <div class="stat"><b>320</b>archival photographs digitised and described</div>
+            <div class="stat"><b>18</b>family journeys mapped with audio guides</div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Museums &amp; education</div>
+        <h2>Project “Talking Collections” for a city library</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Challenge</h3>
+            <p>Create a dialogue-driven exhibition about local philanthropists and make the archive accessible for students and researchers.</p>
+          </div>
+          <div class="card">
+            <h3>Solution</h3>
+            <p>A series of interviews with descendants and experts, synchronised with artefacts, audio guide scripts, and AR markers.</p>
+          </div>
+          <div class="card">
+            <h3>Outcome</h3>
+            <p>An interactive exhibition and a public cabinet in the Eternals Library. Visitors ask the “digital heroes” questions and receive sourced answers.</p>
+          </div>
+          <div class="card">
+            <h3>Impact</h3>
+            <p>+62% exhibition attendance, 12 educational programs, 1.8K dialogues per month.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Corporate memory</div>
+        <h2>“Founder’s Voice” for a tech company</h2>
+        <p>The goal was to preserve leadership knowledge and onboard new executives faster. We interviewed the founder, top managers, and veteran employees, documenting key decisions, crisis playbooks, and the brand’s humour codes.</p>
+        <ul>
+          <li>Launched a dialogue assistant with dedicated modes: strategy sessions, onboarding, and investor Q&amp;A.</li>
+          <li>Produced quote collections and video cases for internal meetups.</li>
+          <li>Implemented an update protocol so fresh stories are verified and published automatically.</li>
+        </ul>
+        <div class="cta-block">
+          <p>Need a digital portrait for your family, foundation, or brand? Tell us about the challenge and we will recommend the best format.</p>
+          <a class="btn" href="mailto:projects@evera.world">Request a consultation</a>
+        </div>
+      </div>
+    </section>
+  </article>
+</main>
+<footer class="footer"><div class="small">© 2025 EVERA</div></footer>
+<script src="/js/app.js"></script>
+</body></html>

--- a/en/pages/eternals.html
+++ b/en/pages/eternals.html
@@ -1,0 +1,201 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Eternals Library | EVERA community of remembered voices</title>
+<meta name="description" content="Explore the Eternals Library with curated digital portraits, dialogues, and legacies from families and cultural icons preserved by EVERA.">
+<meta property="og:title" content="Eternals Library | EVERA community of remembered voices">
+<meta property="og:description" content="Explore the Eternals Library with curated digital portraits, dialogues, and legacies from families and cultural icons preserved by EVERA.">
+<meta property="og:image" content="/evera-logo-white.png">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://evera.world/en/eternals">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Eternals Library | EVERA community of remembered voices">
+<meta name="twitter:description" content="Explore the Eternals Library with curated digital portraits, dialogues, and legacies from families and cultural icons preserved by EVERA.">
+<meta name="twitter:image" content="/evera-logo-white.png">
+  <link rel="icon" href="/assets/icons/favicon.svg">
+<link rel="alternate" hreflang="en" href="https://evera.world/en/eternals">
+<link rel="alternate" hreflang="ru" href="https://evera.world/eternals">
+<link rel="canonical" href="https://evera.world/en/eternals">
+<link rel="stylesheet" href="/css/styles.css">
+</head>
+<body data-nebula="eternals">
+<div class="read-progress" id="readProgress" aria-hidden="true"></div>
+<canvas id="nebula" aria-hidden="true"></canvas>
+<canvas id="stars" aria-hidden="true"></canvas>
+<header class="header">
+  <div class="nav container">
+    <a class="logo" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA logo">
+    </a>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <nav class="links" id="primaryNav" aria-label="Primary navigation">
+      
+      <article lang="en">
+        <div class="menu-group" aria-label="Navigate page sections">
+          <a href="../index.html#mission">Home</a>
+          <a href="../index.html#what">What</a>
+          <a href="../index.html#process">Process</a>
+          <a href="../index.html#ai">AI</a>
+          <a href="../index.html#book">Book of Life</a>
+          <a href="../index.html#eternals">Eternals</a>
+          <a href="../index.html#audience">Audience</a>
+          <a href="../index.html#b2b">Business</a>
+          <a href="../index.html#ethics">Ethics</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+    </nav>
+    <select class="lang-switch" aria-label="Switch language">
+      <option value="ru" data-url="/pages/eternals.html">RU</option>
+      <option value="en" data-url="/en/pages/eternals.html" selected>EN</option>
+    </select>
+  </div>
+</header>
+<div class="nav-overlay" id="navOverlay" hidden></div>
+<aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
+  <div class="nav-drawer__header">
+    <h2 id="menuTitle">
+      
+      <span lang="en">Menu</span>
+    </h2>
+    <button class="nav-drawer__close" id="navClose" aria-label="Close menu">✕</button>
+  </div>
+
+  <nav class="nav-drawer__body stack" aria-label="Site navigation">
+    
+
+    <article lang="en" class="stack">
+      <div class="drawer-group stack">
+        <div class="drawer-title">Sections</div>
+        <a href="../index.html#mission">Home</a>
+        <a href="../index.html#what">What</a>
+        <a href="../index.html#process">Process</a>
+        <a href="../index.html#ai">AI</a>
+        <a href="../index.html#book">Book of Life</a>
+        <a href="../index.html#eternals">Eternals</a>
+        <a href="../index.html#audience">Audience</a>
+        <a href="../index.html#b2b">Business</a>
+        <a href="../index.html#ethics">Ethics</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Pages</div>
+        <a href="pricing.html">Pricing</a>
+        <a href="methodology.html">Methodology</a>
+        <a href="book.html">Book of Life</a>
+        <a href="eternals.html" class="active">Eternals Library</a>
+        <a href="b2b.html">B2B solutions</a>
+        <a href="cases.html">Cases</a>
+        <a href="team.html">Team</a>
+        <a href="roadmap.html">Roadmap</a>
+      </div>
+    </article>
+  </nav>
+  <div class="nav-drawer__footer">
+    <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
+    </a>
+    <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
+      
+      <span lang="en">Telegram channel</span>
+    </a>
+  </div>
+</aside>
+<main>
+  
+  <article class="page-intro" lang="en">
+    <section class="section">
+      <div class="container">
+        <h1>Eternals Library</h1>
+        <p class="lead">A public collection of digital portraits of people whose ideas shape culture, education, and civic life. It is a space for intergenerational dialogue.</p>
+        <div class="pill-list"><span>Education</span><span>Culture</span><span>Civic society</span></div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Mission</div>
+        <h2>Why the library exists</h2>
+        <div class="two-column">
+          <div>
+            <p>We preserve the voices of teachers, researchers, philanthropists, and civic leaders. Their digital portraits are available to schools, museums, and community projects.</p>
+            <p class="quote">“The Eternals” invite honest conversations about values, mistakes, and choices. Every answer shows its source.</p>
+          </div>
+          <div>
+            <h3>Programs</h3>
+            <ul>
+              <li>Educational lessons and history workshops.</li>
+              <li>Museum exhibitions and audio guides.</li>
+              <li>Civic initiatives and urban research.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Criteria</div>
+        <h2>Who we feature</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Documented legacy</h3>
+            <p>Proven achievements and measurable impact on professional or civic communities.</p>
+          </div>
+          <div class="card">
+            <h3>Ethical consent</h3>
+            <p>Permissions from family, foundations, or rights holders, plus clear usage limitations.</p>
+          </div>
+          <div class="card">
+            <h3>Accessible sources</h3>
+            <p>Interviews, letters, photos, and archives ready for analysis and publication.</p>
+          </div>
+          <div class="card">
+            <h3>Educational value</h3>
+            <p>Helps explain values, skills, or historical context through dialogue.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Participation</div>
+        <h2>How to add a portrait</h2>
+        <ul class="timeline">
+          <li><strong>Application.</strong> Send a profile summary, available materials, and your goals.</li>
+          <li><strong>Expert session.</strong> Together we define the format and verify legal status of the sources.</li>
+          <li><strong>Portrait creation.</strong> Interviews, analytics, Book of Life, and dialogue module.</li>
+          <li><strong>Publication.</strong> Launch in the library with learning materials and access policies.</li>
+          <li><strong>Curatorship.</strong> Ongoing updates, feedback collection, and new educational scenarios.</li>
+        </ul>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Partners</div>
+        <h2>Who can use the library</h2>
+        <div class="table-like">
+          <div class="row">
+            <h3>Schools &amp; universities</h3>
+            <p>Access to themed portraits, lesson plans, and licensing for teachers.</p>
+          </div>
+          <div class="row">
+            <h3>Museums &amp; cultural centres</h3>
+            <p>Digital exhibitions, audio guides, and AR markers for showcases.</p>
+          </div>
+          <div class="row">
+            <h3>Foundations &amp; NGOs</h3>
+            <p>Tools for memorial projects, city tours, and documentary programs.</p>
+          </div>
+        </div>
+        <div class="cta-block">
+          <p>Do you know a person who should become part of the Eternals Library? Write to us and receive guidelines on preparing the materials.</p>
+          <a class="btn" href="mailto:eternals@evera.world">Propose a portrait</a>
+        </div>
+      </div>
+    </section>
+  </article>
+</main>
+<footer class="footer"><div class="small">© 2025 EVERA</div></footer>
+<script src="/js/app.js"></script>
+</body></html>

--- a/en/pages/methodology.html
+++ b/en/pages/methodology.html
@@ -1,0 +1,204 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>EVERA Methodology | Interviews, AI analytics & preservation</title>
+<meta name="description" content="See how EVERA combines 150+ questions, speech analytics, and narrative synthesis to create living digital portraits and archives.">
+<meta property="og:title" content="EVERA Methodology | Interviews, AI analytics & preservation">
+<meta property="og:description" content="See how EVERA combines 150+ questions, speech analytics, and narrative synthesis to create living digital portraits and archives.">
+<meta property="og:image" content="/evera-logo-white.png">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://evera.world/en/methodology">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="EVERA Methodology | Interviews, AI analytics & preservation">
+<meta name="twitter:description" content="See how EVERA combines 150+ questions, speech analytics, and narrative synthesis to create living digital portraits and archives.">
+<meta name="twitter:image" content="/evera-logo-white.png">
+  <link rel="icon" href="/assets/icons/favicon.svg">
+<link rel="alternate" hreflang="en" href="https://evera.world/en/methodology">
+<link rel="alternate" hreflang="ru" href="https://evera.world/methodology">
+<link rel="canonical" href="https://evera.world/en/methodology">
+<link rel="stylesheet" href="/css/styles.css">
+</head>
+<body data-nebula="methodology">
+<div class="read-progress" id="readProgress" aria-hidden="true"></div>
+<canvas id="nebula" aria-hidden="true"></canvas>
+<canvas id="stars" aria-hidden="true"></canvas>
+<header class="header">
+  <div class="nav container">
+    <a class="logo" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA logo">
+    </a>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <nav class="links" id="primaryNav" aria-label="Primary navigation">
+      
+      <article lang="en">
+        <div class="menu-group" aria-label="Navigate page sections">
+          <a href="../index.html#mission">Home</a>
+          <a href="../index.html#what">What</a>
+          <a href="../index.html#process">Process</a>
+          <a href="../index.html#ai">AI</a>
+          <a href="../index.html#book">Book of Life</a>
+          <a href="../index.html#eternals">Eternals</a>
+          <a href="../index.html#audience">Audience</a>
+          <a href="../index.html#b2b">Business</a>
+          <a href="../index.html#ethics">Ethics</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+    </nav>
+    <select class="lang-switch" aria-label="Switch language">
+      <option value="ru" data-url="/pages/methodology.html">RU</option>
+      <option value="en" data-url="/en/pages/methodology.html" selected>EN</option>
+    </select>
+  </div>
+</header>
+<div class="nav-overlay" id="navOverlay" hidden></div>
+<aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
+  <div class="nav-drawer__header">
+    <h2 id="menuTitle">
+      
+      <span lang="en">Menu</span>
+    </h2>
+    <button class="nav-drawer__close" id="navClose" aria-label="Close menu">✕</button>
+  </div>
+
+  <nav class="nav-drawer__body stack" aria-label="Site navigation">
+    
+
+    <article lang="en" class="stack">
+      <div class="drawer-group stack">
+        <div class="drawer-title">Sections</div>
+        <a href="../index.html#mission">Home</a>
+        <a href="../index.html#what">What</a>
+        <a href="../index.html#process">Process</a>
+        <a href="../index.html#ai">AI</a>
+        <a href="../index.html#book">Book of Life</a>
+        <a href="../index.html#eternals">Eternals</a>
+        <a href="../index.html#audience">Audience</a>
+        <a href="../index.html#b2b">Business</a>
+        <a href="../index.html#ethics">Ethics</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Pages</div>
+        <a href="pricing.html">Pricing</a>
+        <a href="methodology.html" class="active">Methodology</a>
+        <a href="book.html">Book of Life</a>
+        <a href="eternals.html">Eternals Library</a>
+        <a href="b2b.html">B2B solutions</a>
+        <a href="cases.html">Cases</a>
+        <a href="team.html">Team</a>
+        <a href="roadmap.html">Roadmap</a>
+      </div>
+    </article>
+  </nav>
+  <div class="nav-drawer__footer">
+    <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
+    </a>
+    <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
+      
+      <span lang="en">Telegram channel</span>
+    </a>
+  </div>
+</aside>
+<main>
+  
+  <article class="page-intro" lang="en">
+    <section class="section">
+      <div class="container">
+        <h1>EVERA Methodology</h1>
+        <p class="lead">A certified framework that combines 150+ guided interview questions, cognitive speech analytics, and human editorial review. The result is a digital biography that sounds like the person you remember.</p>
+        <div class="pill-list">
+          <span>150+ questions</span><span>Audio &amp; video</span><span>Ethical review</span><span>Dialogue AI</span>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Principles</div>
+        <h2>What keeps an EVERA portrait authentic</h2>
+        <ul>
+          <li><strong>Voice and memory guide the process.</strong> Technology helps structure the material, yet the family and the narrator approve every step.</li>
+          <li><strong>Verified sources only.</strong> Every fact is checked with documents, witnesses, or archives before entering the final corpus.</li>
+          <li><strong>Transparency and control.</strong> Participants can pause the production or close specific storylines without losing progress.</li>
+          <li><strong>Ethics and consent.</strong> We comply with GDPR, local data regulations, and our internal code of memorial respect.</li>
+        </ul>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Process</div>
+        <h2>From first interview to living dialogue</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Preparation</h3>
+            <p>Onboarding for the family, artefact collection, and roadmap design. A curator helps define priorities, sensitive topics, and narrative limits.</p>
+            <p><strong>Outcome:</strong> approved interview script and data checklist.</p>
+          </div>
+          <div class="card">
+            <h3>Interviews</h3>
+            <p>Three to six sessions, 60–90 minutes each, online or in person. We adapt the questions, trace emotions, and tag people, places, and turning points.</p>
+            <p><strong>Outcome:</strong> transcripts, timestamps, audio and video files.</p>
+          </div>
+          <div class="card">
+            <h3>Analytics</h3>
+            <p>Linguists and analysts build the memory map: storylines, characters, values, emotional markers. AI extracts vocabulary, tone, and conversational tempo.</p>
+            <p><strong>Outcome:</strong> narrative structure and the base dialogue model.</p>
+          </div>
+          <div class="card">
+            <h3>Editorial &amp; Design</h3>
+            <p>The editorial team assembles the Book of Life chapters, creates the quote library, and designs visual inserts. Legal and tonal checks ensure clear attribution.</p>
+            <p><strong>Outcome:</strong> ready-to-print book layout, dialogue scripts, and artefacts for the Eternals Library.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Validation</div>
+        <h2>Quality assurance workflow</h2>
+        <div class="two-column">
+          <div>
+            <h3>Editorial track</h3>
+            <p>Every interview is reviewed twice. We highlight emotional peaks, clarify chronology, and capture quotations for future search layers.</p>
+            <p>Verification calls with relatives and subject-matter experts (historians, educators, archivists) confirm sensitive facts.</p>
+          </div>
+          <div>
+            <h3>Technical track</h3>
+            <p>The AI module analyses semantic clusters, cross-references answers with documents, and flags possible contradictions.</p>
+            <p>A change log records who edited each fragment to preserve transparency and prevent distortions.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Delivery</div>
+        <h2>How we hand over the portrait</h2>
+        <div class="table-like">
+          <div class="row">
+            <h3>Book of Life</h3>
+            <p>Printed or digital edition with themed chapters, QR codes to audio, and family constellation maps.</p>
+          </div>
+          <div class="row">
+            <h3>Dialogue AI</h3>
+            <p>Role-based access in a private portal. Every answer cites the source interview or artefact.</p>
+          </div>
+          <div class="row">
+            <h3>Eternals Library</h3>
+            <p>Public-ready format for cultural and educational institutions with ethical usage guidelines.</p>
+          </div>
+        </div>
+        <div class="cta-block">
+          <p>Wondering whether the EVERA methodology fits your family or project? Share your context and we will draft a tailored research plan.</p>
+          <a class="btn" href="mailto:hello@evera.world">Talk to a curator</a>
+        </div>
+      </div>
+    </section>
+  </article>
+</main>
+<footer class="footer"><div class="small">© 2025 EVERA</div></footer>
+<script src="/js/app.js"></script>
+</body></html>

--- a/en/pages/pricing.html
+++ b/en/pages/pricing.html
@@ -2,11 +2,20 @@
 <html lang="en">
 <head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>EVERA Pricing | Base, Pro, Legacy plans</title>
-<meta name="description" content="Explore EVERA pricing: Base, Pro, and Legacy plans covering interviews, analytics, dialogue AI, and curator support.">
-<link rel="icon" href="/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="en" href="/en/pages/pricing.html">
-<link rel="alternate" hreflang="ru" href="/pages/pricing.html?lang=ru">
+<title>EVERA Pricing | Base, Pro & Legacy plans</title>
+<meta name="description" content="Explore EVERA Base, Pro, and Legacy plans covering interview capture, AI analytics, dialogue models, and curator support.">
+<meta property="og:title" content="EVERA Pricing | Base, Pro & Legacy plans">
+<meta property="og:description" content="Explore EVERA Base, Pro, and Legacy plans covering interview capture, AI analytics, dialogue models, and curator support.">
+<meta property="og:image" content="/evera-logo-white.png">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://evera.world/en/pricing">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="EVERA Pricing | Base, Pro & Legacy plans">
+<meta name="twitter:description" content="Explore EVERA Base, Pro, and Legacy plans covering interview capture, AI analytics, dialogue models, and curator support.">
+<meta name="twitter:image" content="/evera-logo-white.png">
+  <link rel="icon" href="/assets/icons/favicon.svg">
+<link rel="alternate" hreflang="en" href="https://evera.world/en/pricing">
+<link rel="alternate" hreflang="ru" href="https://evera.world/pricing">
 <link rel="canonical" href="https://evera.world/en/pricing">
 <link rel="stylesheet" href="/css/styles.css">
 </head>
@@ -16,43 +25,30 @@
 <canvas id="stars" aria-hidden="true"></canvas>
 <header class="header">
   <div class="nav container">
-    <a class="logo" href="../../index.html#mission" aria-label="EVERA">
-      <img src="../../evera-logo-white.svg" alt="EVERA logo">
+    <a class="logo" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA logo">
     </a>
-    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Menu / Меню" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
     <nav class="links" id="primaryNav" aria-label="Primary navigation">
-      <article data-lang="ru" lang="ru" hidden>
-        <div class="menu-group" aria-label="Навигация по разделам страницы">
-          <a href="../../index.html#mission">Главная</a>
-          <a href="../../index.html#what">Что такое</a>
-          <a href="../../index.html#process">Процесс</a>
-          <a href="../../index.html#ai">ИИ</a>
-          <a href="../../index.html#book">Книга Жизни</a>
-          <a href="../../index.html#eternals">Вечные</a>
-          <a href="../../index.html#audience">Для кого</a>
-          <a href="../../index.html#b2b">Бизнес</a>
-          <a href="../../index.html#ethics">Этика</a>
-          <a href="../../index.html#faq">FAQ</a>
-        </div>
-      </article>
-      <article data-lang="en" lang="en">
+      
+      <article lang="en">
         <div class="menu-group" aria-label="Navigate page sections">
-          <a href="../../index.html#mission">Home</a>
-          <a href="../../index.html#what">What</a>
-          <a href="../../index.html#process">Process</a>
-          <a href="../../index.html#ai">AI</a>
-          <a href="../../index.html#book">Book of Life</a>
-          <a href="../../index.html#eternals">Eternals</a>
-          <a href="../../index.html#audience">Audience</a>
-          <a href="../../index.html#b2b">Business</a>
-          <a href="../../index.html#ethics">Ethics</a>
-          <a href="../../index.html#faq">FAQ</a>
+          <a href="../index.html#mission">Home</a>
+          <a href="../index.html#what">What</a>
+          <a href="../index.html#process">Process</a>
+          <a href="../index.html#ai">AI</a>
+          <a href="../index.html#book">Book of Life</a>
+          <a href="../index.html#eternals">Eternals</a>
+          <a href="../index.html#audience">Audience</a>
+          <a href="../index.html#b2b">Business</a>
+          <a href="../index.html#ethics">Ethics</a>
+          <a href="../index.html#faq">FAQ</a>
         </div>
       </article>
     </nav>
     <select class="lang-switch" aria-label="Switch language">
-      <option value="ru">RU</option>
-      <option value="en" selected>EN</option>
+      <option value="ru" data-url="/pages/pricing.html">RU</option>
+      <option value="en" data-url="/en/pages/pricing.html" selected>EN</option>
     </select>
   </div>
 </header>
@@ -60,98 +56,60 @@
 <aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
   <div class="nav-drawer__header">
     <h2 id="menuTitle">
-      <span data-lang="ru" lang="ru">Меню</span>
-      <span data-lang="en" lang="en">Menu</span>
+      
+      <span lang="en">Menu</span>
     </h2>
-    <button class="nav-drawer__close" id="navClose" aria-label="Close menu / Закрыть меню">✕</button>
+    <button class="nav-drawer__close" id="navClose" aria-label="Close menu">✕</button>
   </div>
 
   <nav class="nav-drawer__body stack" aria-label="Site navigation">
-    <article data-lang="ru" lang="ru" class="stack">
-      <div class="drawer-group stack">
-        <div class="drawer-title">Разделы</div>
-        <a href="../../index.html#mission">Главная</a>
-        <a href="../../index.html#what">Что такое</a>
-        <a href="../../index.html#process">Процесс</a>
-        <a href="../../index.html#ai">ИИ</a>
-        <a href="../../index.html#book">Книга Жизни</a>
-        <a href="../../index.html#eternals">Вечные</a>
-        <a href="../../index.html#audience">Для кого</a>
-        <a href="../../index.html#b2b">Бизнес</a>
-        <a href="../../index.html#ethics">Этика</a>
-        <a href="../../index.html#faq">FAQ</a>
-      </div>
+    
 
-      <div class="drawer-group stack">
-        <div class="drawer-title">Страницы</div>
-        <a href="../../pages/pricing.html" data-href-ru="../../pages/pricing.html" data-href-en="pricing.html">Тарифы</a>
-        <a href="../../pages/methodology.html" data-href-ru="../../pages/methodology.html" data-href-en="../../pages/methodology.html?lang=en">Методология</a>
-        <a href="../../pages/book.html" data-href-ru="../../pages/book.html" data-href-en="../../pages/book.html?lang=en">Издание «Книга Жизни»</a>
-        <a href="../../pages/eternals.html" data-href-ru="../../pages/eternals.html" data-href-en="../../pages/eternals.html?lang=en">Библиотека «Вечных»</a>
-        <a href="../../pages/b2b.html" data-href-ru="../../pages/b2b.html" data-href-en="../../pages/b2b.html?lang=en">Корпоративные решения</a>
-        <a href="../../pages/cases.html" data-href-ru="../../pages/cases.html" data-href-en="../../pages/cases.html?lang=en">Кейсы</a>
-        <a href="../../pages/team.html" data-href-ru="../../pages/team.html" data-href-en="../../pages/team.html?lang=en">Команда</a>
-        <a href="../../pages/roadmap.html" data-href-ru="../../pages/roadmap.html" data-href-en="../../pages/roadmap.html?lang=en">Роадмап</a>
-      </div>
-    </article>
-
-    <article data-lang="en" lang="en" class="stack">
+    <article lang="en" class="stack">
       <div class="drawer-group stack">
         <div class="drawer-title">Sections</div>
-        <a href="../../index.html#mission">Home</a>
-        <a href="../../index.html#what">What</a>
-        <a href="../../index.html#process">Process</a>
-        <a href="../../index.html#ai">AI</a>
-        <a href="../../index.html#book">Book of Life</a>
-        <a href="../../index.html#eternals">Eternals</a>
-        <a href="../../index.html#audience">Audience</a>
-        <a href="../../index.html#b2b">Business</a>
-        <a href="../../index.html#ethics">Ethics</a>
-        <a href="../../index.html#faq">FAQ</a>
+        <a href="../index.html#mission">Home</a>
+        <a href="../index.html#what">What</a>
+        <a href="../index.html#process">Process</a>
+        <a href="../index.html#ai">AI</a>
+        <a href="../index.html#book">Book of Life</a>
+        <a href="../index.html#eternals">Eternals</a>
+        <a href="../index.html#audience">Audience</a>
+        <a href="../index.html#b2b">Business</a>
+        <a href="../index.html#ethics">Ethics</a>
+        <a href="../index.html#faq">FAQ</a>
       </div>
 
       <div class="drawer-group stack">
         <div class="drawer-title">Pages</div>
-        <a href="pricing.html" data-href-ru="../../pages/pricing.html" data-href-en="pricing.html" class="active">Pricing</a>
-        <a href="../../pages/methodology.html?lang=en" data-href-ru="../../pages/methodology.html" data-href-en="../../pages/methodology.html?lang=en">Methodology</a>
-        <a href="../../pages/book.html?lang=en" data-href-ru="../../pages/book.html" data-href-en="../../pages/book.html?lang=en">Book of Life</a>
-        <a href="../../pages/eternals.html?lang=en" data-href-ru="../../pages/eternals.html" data-href-en="../../pages/eternals.html?lang=en">Eternals Library</a>
-        <a href="../../pages/b2b.html?lang=en" data-href-ru="../../pages/b2b.html" data-href-en="../../pages/b2b.html?lang=en">B2B solutions</a>
-        <a href="../../pages/cases.html?lang=en" data-href-ru="../../pages/cases.html" data-href-en="../../pages/cases.html?lang=en">Cases</a>
-        <a href="../../pages/team.html?lang=en" data-href-ru="../../pages/team.html" data-href-en="../../pages/team.html?lang=en">Team</a>
-        <a href="../../pages/roadmap.html?lang=en" data-href-ru="../../pages/roadmap.html" data-href-en="../../pages/roadmap.html?lang=en">Roadmap</a>
+        <a href="pricing.html" class="active">Pricing</a>
+        <a href="methodology.html">Methodology</a>
+        <a href="book.html">Book of Life</a>
+        <a href="eternals.html">Eternals Library</a>
+        <a href="b2b.html">B2B solutions</a>
+        <a href="cases.html">Cases</a>
+        <a href="team.html">Team</a>
+        <a href="roadmap.html">Roadmap</a>
       </div>
     </article>
   </nav>
   <div class="nav-drawer__footer">
-    <a class="drawer-brand" href="../../index.html#mission" aria-label="EVERA">
-      <img src="../../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
+    <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
     </a>
     <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
-      <span data-lang="ru" lang="ru">Telegram-канал</span>
-      <span data-lang="en" lang="en">Telegram channel</span>
+      
+      <span lang="en">Telegram channel</span>
     </a>
   </div>
 </aside>
 <main>
-  <article class="page-intro" data-lang="ru" lang="ru" hidden>
-    <section class="section">
-      <div class="container">
-        <h1>Тарифы EVERA</h1>
-        <p class="lead">Русская версия страницы доступна по ссылке ниже.</p>
-        <div class="cta-block">
-          <div class="cta-actions">
-            <a class="btn" href="/pages/pricing.html">Открыть тарифы на русском</a>
-          </div>
-        </div>
-      </div>
-    </section>
-  </article>
-  <article class="page-intro" data-lang="en" lang="en">
+  
+  <article class="page-intro" lang="en">
     <section class="section">
       <div class="container">
         <h1>EVERA Pricing</h1>
-        <p class="lead">Choose the format that fits your legacy: from a family Book of Life to a corporate knowledge base with conversational AI. Every plan combines interviews, analytics, and curator-guided launch.</p>
+        <p class="lead">Choose the format that fits your story: from a family Book of Life to a corporate knowledge base with conversational AI. Every tier bundles interviews, analytics, and guided launch.</p>
         <div class="pill-list"><span>150+ prompts</span><span>AI archive</span><span>Dialogue access</span><span>Editorial team</span></div>
       </div>
     </section>
@@ -165,7 +123,7 @@
             <div class="price">120,000&nbsp;₽</div>
             <p class="meta">6 weeks, one protagonist, digital Book of Life delivery.</p>
             <ul>
-              <li>Up to three interviews (remote or on-site) with 150+ prompts.</li>
+              <li>Up to three interviews (remote/on-site) covering 150+ prompts.</li>
               <li>Speech, emotion, and theme analytics with curator notes.</li>
               <li>Digital Book of Life (PDF) with timeline, quotes, and media.</li>
               <li>Foundational dialogue model with private family access.</li>
@@ -180,7 +138,7 @@
               <li>Up to six interviews plus bonus sessions with relatives or partners.</li>
               <li>Advanced analytics: timelines, genealogy, semantic mapping.</li>
               <li>Dialogue AI with themed modes and citation links to sources.</li>
-              <li>Family portal with access governance and onboarding workshop.</li>
+              <li>Family portal with access management and onboarding workshop.</li>
             </ul>
             <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20Pro%20-%20Request%20a%20quote">Request a quote</a>
           </div>

--- a/en/pages/roadmap.html
+++ b/en/pages/roadmap.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>EVERA Roadmap | Upcoming releases & community plans</title>
+<meta name="description" content="Track EVERA milestones: new interview modules, AI dialogue updates, publishing formats, and community features for living digital legacies.">
+<meta property="og:title" content="EVERA Roadmap | Upcoming releases & community plans">
+<meta property="og:description" content="Track EVERA milestones: new interview modules, AI dialogue updates, publishing formats, and community features for living digital legacies.">
+<meta property="og:image" content="/evera-logo-white.png">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://evera.world/en/roadmap">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="EVERA Roadmap | Upcoming releases & community plans">
+<meta name="twitter:description" content="Track EVERA milestones: new interview modules, AI dialogue updates, publishing formats, and community features for living digital legacies.">
+<meta name="twitter:image" content="/evera-logo-white.png">
+  <link rel="icon" href="/assets/icons/favicon.svg">
+<link rel="alternate" hreflang="en" href="https://evera.world/en/roadmap">
+<link rel="alternate" hreflang="ru" href="https://evera.world/roadmap">
+<link rel="canonical" href="https://evera.world/en/roadmap">
+<link rel="stylesheet" href="/css/styles.css">
+</head>
+<body data-nebula="roadmap">
+<div class="read-progress" id="readProgress" aria-hidden="true"></div>
+<canvas id="nebula" aria-hidden="true"></canvas>
+<canvas id="stars" aria-hidden="true"></canvas>
+<header class="header">
+  <div class="nav container">
+    <a class="logo" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA logo">
+    </a>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <nav class="links" id="primaryNav" aria-label="Primary navigation">
+      
+      <article lang="en">
+        <div class="menu-group" aria-label="Navigate page sections">
+          <a href="../index.html#mission">Home</a>
+          <a href="../index.html#what">What</a>
+          <a href="../index.html#process">Process</a>
+          <a href="../index.html#ai">AI</a>
+          <a href="../index.html#book">Book of Life</a>
+          <a href="../index.html#eternals">Eternals</a>
+          <a href="../index.html#audience">Audience</a>
+          <a href="../index.html#b2b">Business</a>
+          <a href="../index.html#ethics">Ethics</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+    </nav>
+    <select class="lang-switch" aria-label="Switch language">
+      <option value="ru" data-url="/pages/roadmap.html">RU</option>
+      <option value="en" data-url="/en/pages/roadmap.html" selected>EN</option>
+    </select>
+  </div>
+</header>
+<div class="nav-overlay" id="navOverlay" hidden></div>
+<aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
+  <div class="nav-drawer__header">
+    <h2 id="menuTitle">
+      
+      <span lang="en">Menu</span>
+    </h2>
+    <button class="nav-drawer__close" id="navClose" aria-label="Close menu">✕</button>
+  </div>
+
+  <nav class="nav-drawer__body stack" aria-label="Site navigation">
+    
+
+    <article lang="en" class="stack">
+      <div class="drawer-group stack">
+        <div class="drawer-title">Sections</div>
+        <a href="../index.html#mission">Home</a>
+        <a href="../index.html#what">What</a>
+        <a href="../index.html#process">Process</a>
+        <a href="../index.html#ai">AI</a>
+        <a href="../index.html#book">Book of Life</a>
+        <a href="../index.html#eternals">Eternals</a>
+        <a href="../index.html#audience">Audience</a>
+        <a href="../index.html#b2b">Business</a>
+        <a href="../index.html#ethics">Ethics</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Pages</div>
+        <a href="pricing.html">Pricing</a>
+        <a href="methodology.html">Methodology</a>
+        <a href="book.html">Book of Life</a>
+        <a href="eternals.html">Eternals Library</a>
+        <a href="b2b.html">B2B solutions</a>
+        <a href="cases.html">Cases</a>
+        <a href="team.html">Team</a>
+        <a href="roadmap.html" class="active">Roadmap</a>
+      </div>
+    </article>
+  </nav>
+  <div class="nav-drawer__footer">
+    <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
+    </a>
+    <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
+      
+      <span lang="en">Telegram channel</span>
+    </a>
+  </div>
+</aside>
+<main>
+  
+  <article class="page-intro" lang="en">
+    <section class="section">
+      <div class="container">
+        <h1>EVERA Roadmap</h1>
+        <p class="lead">We are building a product that unites digital biographies, dialogue AI, and ethical memorial practices. Here are the milestones planned for 2024–2026.</p>
+        <div class="pill-list"><span>2024</span><span>2025</span><span>2026</span></div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Product</div>
+        <h2>Upcoming releases</h2>
+        <ul class="timeline">
+          <li><strong>Q2 2024: Book of Life 2.0.</strong> New layout editor, dynamic QR modules, and an expanded emotion glossary.</li>
+          <li><strong>Q3 2024: Private family portal.</strong> Role-based permissions, edit logs, and secure artefact sharing.</li>
+          <li><strong>Q1 2025: Voice-enabled dialogue AI.</strong> Expressive speech synthesis based on approved samples with transparent citations.</li>
+          <li><strong>Q3 2025: Public portraits.</strong> First collections released in the Eternals Library with ready-to-use lesson plans.</li>
+          <li><strong>2026: Global launch.</strong> Multilingual support, partnerships with archives, and an API for research centres.</li>
+        </ul>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Research</div>
+        <h2>Exploration tracks</h2>
+        <div class="cards-grid">
+          <div class="card">
+            <h3>Ethics &amp; legal frameworks</h3>
+            <p>We design a code of conduct for digital twins and template agreements for families, museums, and companies.</p>
+          </div>
+          <div class="card">
+            <h3>Narrative analytics</h3>
+            <p>Studying how emotions and vocabulary reflect personal values and teaching the AI to cite sources correctly.</p>
+          </div>
+          <div class="card">
+            <h3>Multiformat archives</h3>
+            <p>Building a pipeline that preserves audio, video, letters, and artefacts so the portrait stays relevant for decades.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Impact</div>
+        <h2>Success indicators</h2>
+        <div class="stat-grid">
+          <div class="stat"><b>500+</b>families and institutions in the ecosystem</div>
+          <div class="stat"><b>80%</b>portraits refreshed every year</div>
+          <div class="stat"><b>15</b>international partner institutions</div>
+        </div>
+        <div class="cta-block">
+          <p>Interested in pilots or research collaborations? Write to us and we will discuss access to early releases.</p>
+          <a class="btn" href="mailto:roadmap@evera.world">Join the pilot</a>
+        </div>
+      </div>
+    </section>
+  </article>
+</main>
+<footer class="footer"><div class="small">© 2025 EVERA</div></footer>
+<script src="/js/app.js"></script>
+</body></html>

--- a/en/pages/team.html
+++ b/en/pages/team.html
@@ -1,0 +1,199 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>EVERA Team | Researchers, storytellers & engineers</title>
+<meta name="description" content="Meet the EVERA team of historians, interviewers, AI specialists, and designers building responsible tools for digital memory and legacy.">
+<meta property="og:title" content="EVERA Team | Researchers, storytellers & engineers">
+<meta property="og:description" content="Meet the EVERA team of historians, interviewers, AI specialists, and designers building responsible tools for digital memory and legacy.">
+<meta property="og:image" content="/evera-logo-white.png">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://evera.world/en/team">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="EVERA Team | Researchers, storytellers & engineers">
+<meta name="twitter:description" content="Meet the EVERA team of historians, interviewers, AI specialists, and designers building responsible tools for digital memory and legacy.">
+<meta name="twitter:image" content="/evera-logo-white.png">
+  <link rel="icon" href="/assets/icons/favicon.svg">
+<link rel="alternate" hreflang="en" href="https://evera.world/en/team">
+<link rel="alternate" hreflang="ru" href="https://evera.world/team">
+<link rel="canonical" href="https://evera.world/en/team">
+<link rel="stylesheet" href="/css/styles.css">
+</head>
+<body data-nebula="team">
+<div class="read-progress" id="readProgress" aria-hidden="true"></div>
+<canvas id="nebula" aria-hidden="true"></canvas>
+<canvas id="stars" aria-hidden="true"></canvas>
+<header class="header">
+  <div class="nav container">
+    <a class="logo" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA logo">
+    </a>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <nav class="links" id="primaryNav" aria-label="Primary navigation">
+      
+      <article lang="en">
+        <div class="menu-group" aria-label="Navigate page sections">
+          <a href="../index.html#mission">Home</a>
+          <a href="../index.html#what">What</a>
+          <a href="../index.html#process">Process</a>
+          <a href="../index.html#ai">AI</a>
+          <a href="../index.html#book">Book of Life</a>
+          <a href="../index.html#eternals">Eternals</a>
+          <a href="../index.html#audience">Audience</a>
+          <a href="../index.html#b2b">Business</a>
+          <a href="../index.html#ethics">Ethics</a>
+          <a href="../index.html#faq">FAQ</a>
+        </div>
+      </article>
+    </nav>
+    <select class="lang-switch" aria-label="Switch language">
+      <option value="ru" data-url="/pages/team.html">RU</option>
+      <option value="en" data-url="/en/pages/team.html" selected>EN</option>
+    </select>
+  </div>
+</header>
+<div class="nav-overlay" id="navOverlay" hidden></div>
+<aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
+  <div class="nav-drawer__header">
+    <h2 id="menuTitle">
+      
+      <span lang="en">Menu</span>
+    </h2>
+    <button class="nav-drawer__close" id="navClose" aria-label="Close menu">✕</button>
+  </div>
+
+  <nav class="nav-drawer__body stack" aria-label="Site navigation">
+    
+
+    <article lang="en" class="stack">
+      <div class="drawer-group stack">
+        <div class="drawer-title">Sections</div>
+        <a href="../index.html#mission">Home</a>
+        <a href="../index.html#what">What</a>
+        <a href="../index.html#process">Process</a>
+        <a href="../index.html#ai">AI</a>
+        <a href="../index.html#book">Book of Life</a>
+        <a href="../index.html#eternals">Eternals</a>
+        <a href="../index.html#audience">Audience</a>
+        <a href="../index.html#b2b">Business</a>
+        <a href="../index.html#ethics">Ethics</a>
+        <a href="../index.html#faq">FAQ</a>
+      </div>
+
+      <div class="drawer-group stack">
+        <div class="drawer-title">Pages</div>
+        <a href="pricing.html">Pricing</a>
+        <a href="methodology.html">Methodology</a>
+        <a href="book.html">Book of Life</a>
+        <a href="eternals.html">Eternals Library</a>
+        <a href="b2b.html">B2B solutions</a>
+        <a href="cases.html">Cases</a>
+        <a href="team.html" class="active">Team</a>
+        <a href="roadmap.html">Roadmap</a>
+      </div>
+    </article>
+  </nav>
+  <div class="nav-drawer__footer">
+    <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
+      <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
+    </a>
+    <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
+      
+      <span lang="en">Telegram channel</span>
+    </a>
+  </div>
+</aside>
+<main>
+  
+  <article class="page-intro" lang="en">
+    <section class="section">
+      <div class="container">
+        <h1>The EVERA Team</h1>
+        <p class="lead">We are memory curators, editors, engineers, and researchers who transform life stories into digital dialogue. Our mission is to preserve a person’s voice and values with respect for their family and culture.</p>
+        <div class="pill-list"><span>Curatorship</span><span>Editorial</span><span>AI</span><span>Ethics</span></div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Approach</div>
+        <h2>Team philosophy</h2>
+        <ul>
+          <li>We work in cross-functional cells that unite researchers, linguists, and designers around each portrait.</li>
+          <li>Every client collaborates with a dedicated curator responsible for empathy, timing, and communication.</li>
+          <li>We follow the principle “nothing about a person without their family” by aligning context and tone in every story.</li>
+        </ul>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Core team</div>
+        <h2>Key roles</h2>
+        <div class="profile-grid">
+          <div class="profile-card">
+            <div class="role">Founder &amp; Vision</div>
+            <h3>Anastasia Vyushina</h3>
+            <p>Founder of EVERA and curator of digital memory projects. Leads strategy, ethics, and international partnerships.</p>
+            <p><strong>Focus:</strong> mission, partnerships, public outreach.</p>
+          </div>
+          <div class="profile-card">
+            <div class="role">Research Director</div>
+            <h3>Dmitry Soloukhin</h3>
+            <p>Narrative researcher with a PhD in cultural studies. Oversees interview methodology and analytical frameworks.</p>
+            <p><strong>Focus:</strong> interview scripts, data validation, curator training.</p>
+          </div>
+          <div class="profile-card">
+            <div class="role">Chief Editor</div>
+            <h3>Maria Klimova</h3>
+            <p>Editor and literary producer experienced in biographies of cultural leaders and educational programs.</p>
+            <p><strong>Focus:</strong> Book of Life, style, fact-checking.</p>
+          </div>
+          <div class="profile-card">
+            <div class="role">AI Architect</div>
+            <h3>Ilya Kim</h3>
+            <p>Machine learning engineer with 10 years in NLP and conversational systems. Builds the memory model and citation layer.</p>
+            <p><strong>Focus:</strong> speech analytics, voice models, data security.</p>
+          </div>
+          <div class="profile-card">
+            <div class="role">Design Lead</div>
+            <h3>Alena Morozova</h3>
+            <p>Art director crafting the visual language of the Book of Life and leading the design and illustration team.</p>
+            <p><strong>Focus:</strong> visual patterns, interactive prototypes.</p>
+          </div>
+          <div class="profile-card">
+            <div class="role">Community &amp; Ethics</div>
+            <h3>Oleg Andreev</h3>
+            <p>Ethics specialist and moderator of memorial communities. Maintains the code of conduct and family agreements.</p>
+            <p><strong>Focus:</strong> access policies, learning sessions, family support.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <div class="kicker">Advisory board</div>
+        <h2>Expert partners</h2>
+        <div class="table-like">
+          <div class="row">
+            <h3>Historians &amp; archivists</h3>
+            <p>Verify documents, structure timelines, and advise on long-term preservation of artefacts.</p>
+          </div>
+          <div class="row">
+            <h3>Psychologists &amp; facilitators</h3>
+            <p>Guide sensitive interviews, support families, and suggest safe frameworks for discussing difficult memories.</p>
+          </div>
+          <div class="row">
+            <h3>IP lawyers</h3>
+            <p>Review copyright, regulate access to digital assets, and draft licensing agreements.</p>
+          </div>
+        </div>
+        <div class="cta-block">
+          <p>We welcome collaboration with researchers, artists, and scholars. Reach out if you want to join the team or co-create a project.</p>
+          <a class="btn" href="mailto:team@evera.world">Contact us</a>
+        </div>
+      </div>
+    </section>
+  </article>
+</main>
+<footer class="footer"><div class="small">© 2025 EVERA</div></footer>
+<script src="/js/app.js"></script>
+</body></html>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,10 @@
   <!-- Favicon & manifest -->
   <!-- Use relative paths so the site works on GitHub Pages and custom domains -->
   <link rel="icon" href="evera-logo-white.svg">
+  <link rel="canonical" href="https://evera.world/">
   <link rel="manifest" href="manifest.json">
+  <link rel="alternate" hreflang="ru" href="https://evera.world/">
+  <link rel="alternate" hreflang="en" href="https://evera.world/en/">
   <!-- OpenGraph tags -->
   <meta property="og:title" content="EVERA | Живая память и цифровое бессмертие">
   <meta property="og:description" content="Интервью 150+ вопросов, анализ речи и эмоций, «Книга Жизни» и Библиотека «Вечных». Сохраняем голос и смысл, чтобы говорить через годы.">
@@ -42,9 +45,9 @@
       <a class="logo" href="#mission" aria-label="EVERA">
         <img src="evera-logo-white.svg" alt="EVERA logo">
       </a>
-      <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню / Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+      <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню" aria-expanded="false" aria-controls="navDrawer">☰</button>
       <nav class="links" id="primaryNav" aria-label="Основная навигация">
-        <article data-lang="ru" lang="ru">
+        <article lang="ru">
           <div class="menu-group" aria-label="Навигация по разделам страницы">
             <a href="#mission" class="active">Главная</a>
             <a href="#what">Что такое</a>
@@ -58,24 +61,11 @@
             <a href="#faq">FAQ</a>
           </div>
         </article>
-        <article data-lang="en" lang="en" hidden>
-          <div class="menu-group" aria-label="Navigate page sections">
-            <a href="#mission" class="active">Home</a>
-            <a href="#what">What</a>
-            <a href="#process">Process</a>
-            <a href="#ai">AI</a>
-            <a href="#book">Book of Life</a>
-            <a href="#eternals">Eternals</a>
-            <a href="#audience">Audience</a>
-            <a href="#b2b">Business</a>
-            <a href="#ethics">Ethics</a>
-            <a href="#faq">FAQ</a>
-          </div>
-        </article>
+        
       </nav>
-      <select class="lang-switch" aria-label="Switch language">
-        <option value="ru">RU</option>
-        <option value="en">EN</option>
+      <select class="lang-switch" aria-label="Переключить язык">
+        <option value="ru" data-url="/index.html" selected>RU</option>
+        <option value="en" data-url="/en/index.html">EN</option>
       </select>
     </div>
   </header>
@@ -84,14 +74,14 @@
   <aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
     <div class="nav-drawer__header">
       <h2 id="menuTitle">
-        <span data-lang="ru" lang="ru">Меню</span>
-        <span data-lang="en" lang="en" hidden>Menu</span>
+        <span lang="ru">Меню</span>
+        
       </h2>
-      <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню / Close menu">✕</button>
+      <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню">✕</button>
     </div>
 
     <nav class="nav-drawer__body stack" aria-label="Навигация по сайту">
-      <article data-lang="ru" lang="ru" class="stack">
+      <article lang="ru" class="stack">
         <div class="drawer-group stack">
           <div class="drawer-title">Разделы</div>
           <a href="#mission">Главная</a>
@@ -108,52 +98,26 @@
 
         <div class="drawer-group stack">
           <div class="drawer-title">Страницы</div>
-          <a href="pages/pricing.html" data-href-ru="pages/pricing.html" data-href-en="pages/pricing.html?lang=en">Тарифы</a>
-          <a href="pages/methodology.html" data-href-ru="pages/methodology.html" data-href-en="pages/methodology.html?lang=en">Методология</a>
-          <a href="pages/book.html" data-href-ru="pages/book.html" data-href-en="pages/book.html?lang=en">Издание «Книга Жизни»</a>
-          <a href="pages/eternals.html" data-href-ru="pages/eternals.html" data-href-en="pages/eternals.html?lang=en">Библиотека «Вечных»</a>
-          <a href="pages/b2b.html" data-href-ru="pages/b2b.html" data-href-en="pages/b2b.html?lang=en">Корпоративные решения</a>
-          <a href="pages/cases.html" data-href-ru="pages/cases.html" data-href-en="pages/cases.html?lang=en">Кейсы</a>
-          <a href="pages/team.html" data-href-ru="pages/team.html" data-href-en="pages/team.html?lang=en">Команда</a>
-          <a href="pages/roadmap.html" data-href-ru="pages/roadmap.html" data-href-en="pages/roadmap.html?lang=en">Роадмап</a>
+          <a href="pages/pricing.html">Тарифы</a>
+          <a href="pages/methodology.html">Методология</a>
+          <a href="pages/book.html">Издание «Книга Жизни»</a>
+          <a href="pages/eternals.html">Библиотека «Вечных»</a>
+          <a href="pages/b2b.html">Корпоративные решения</a>
+          <a href="pages/cases.html">Кейсы</a>
+          <a href="pages/team.html">Команда</a>
+          <a href="pages/roadmap.html">Роадмап</a>
         </div>
       </article>
 
-      <article data-lang="en" lang="en" class="stack" hidden>
-        <div class="drawer-group stack">
-          <div class="drawer-title">Sections</div>
-          <a href="#mission">Home</a>
-          <a href="#what">What</a>
-          <a href="#process">Process</a>
-          <a href="#ai">AI</a>
-          <a href="#book">Book of Life</a>
-          <a href="#eternals">Eternals</a>
-          <a href="#audience">Audience</a>
-          <a href="#b2b">Business</a>
-          <a href="#ethics">Ethics</a>
-          <a href="#faq">FAQ</a>
-        </div>
-
-        <div class="drawer-group stack">
-          <div class="drawer-title">Pages</div>
-          <a href="pages/pricing.html" data-href-ru="pages/pricing.html" data-href-en="pages/pricing.html?lang=en">Pricing</a>
-          <a href="pages/methodology.html" data-href-ru="pages/methodology.html" data-href-en="pages/methodology.html?lang=en">Methodology</a>
-          <a href="pages/book.html" data-href-ru="pages/book.html" data-href-en="pages/book.html?lang=en">Book of Life</a>
-          <a href="pages/eternals.html" data-href-ru="pages/eternals.html" data-href-en="pages/eternals.html?lang=en">Eternals Library</a>
-          <a href="pages/b2b.html" data-href-ru="pages/b2b.html" data-href-en="pages/b2b.html?lang=en">B2B solutions</a>
-          <a href="pages/cases.html" data-href-ru="pages/cases.html" data-href-en="pages/cases.html?lang=en">Cases</a>
-          <a href="pages/team.html" data-href-ru="pages/team.html" data-href-en="pages/team.html?lang=en">Team</a>
-          <a href="pages/roadmap.html" data-href-ru="pages/roadmap.html" data-href-en="pages/roadmap.html?lang=en">Roadmap</a>
-        </div>
-      </article>
+      
     </nav>
     <div class="nav-drawer__footer">
       <a class="drawer-brand" href="#mission" aria-label="EVERA">
         <img src="/evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
       </a>
       <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
-        <span data-lang="ru" lang="ru">Telegram-канал</span>
-        <span data-lang="en" lang="en" hidden>Telegram channel</span>
+        <span lang="ru">Telegram-канал</span>
+        
       </a>
     </div>
   </aside>
@@ -161,7 +125,7 @@
   <main>
     <!-- Hero/mission: короткий призыв и основная идея -->
     <section id="mission" class="hero section">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="container reveal stack" data-parallax-speed="0.01">
           <div class="overlay stack">
             <h1>EVERA<br>Живая память<br>Портал в вечность</h1>
@@ -184,34 +148,12 @@
           </div>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="container reveal stack" data-parallax-speed="0.01">
-          <div class="overlay stack">
-            <h1>EVERA<br>Living memory<br>Portal to eternity</h1>
-            <p class="lead">
-              We preserve voices, stories, and values so descendants can speak with you across decades.
-              150+ interview prompts, speech analytics, and the Book of Life turn memory into a living dialogue.
-            </p>
-            <div class="cta stack">
-              <a class="btn" href="#process">See how it works</a>
-              <a class="btn ghost" href="https://t.me/sololabschannel" target="_blank" rel="noopener">Telegram channel</a>
-            </div>
-            <div class="stat-grid reveal-stagger">
-              <div class="stat"><b>150+</b>deep-dive interview prompts</div>
-              <div class="stat"><b>1&nbsp;M+</b>words — minimum data set</div>
-              <div class="stat"><b>24/7</b>access to the digital portrait</div>
-              <div class="stat"><b>100%</b>privacy and access control</div>
-              <div class="stat"><b>20+</b>emotional and semantic metrics</div>
-              <div class="stat">Book of Life edition based on biography</div>
-            </div>
-          </div>
-        </div>
-      </article>
+      
     </section>
 
     <!-- Миссия и польза -->
     <section id="overview" class="section">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="container reveal stack">
           <h2>Миссия EVERA</h2>
           <p>EVERA - это пространство, где голоса не стихают. Мы бережно превращаем воспоминания, речь, ценности и
@@ -221,22 +163,12 @@
             акценты. Итог - оцифровка памяти и цифровое наследие, доступное семье и при желании - миру.</p>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="container reveal stack">
-          <h2>EVERA mission</h2>
-          <p>EVERA is a space where voices never fade. We carefully transform memories, speech, values, and personal
-            stories into a digital portrait that descendants, students, and researchers can converse with. It is not
-            a cold archive or questionnaire — it is a living dialogue across time.</p>
-          <p>You preserve what must not be lost: intonations, signature phrases, biographical facts, and emotional
-            emphasis. The result is a digitised legacy that remains available to the family — and, if you wish, to the
-            world.</p>
-        </div>
-      </article>
+      
     </section>
 
     <!-- Что такое EVERA -->
     <section id="what" class="section">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="container reveal stack">
           <h2>Что такое EVERA?</h2>
           <p>EVERA - это метод и платформа для создания цифрового бессмертия на языке семьи и культуры. Мы собираем
@@ -249,23 +181,12 @@
             контекст и границы.</p>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="container reveal stack">
-          <h2>What is EVERA?</h2>
-          <p>EVERA is a method and platform for creating digital immortality in the language of your family and culture.
-            We gather audio and video interviews, letters, and photos, build a biographical timeline, and capture
-            lexical style and emotional markers. These sources form a digital portrait able to sustain themed
-            conversations.</p>
-          <p>Unlike impersonal archives or rigid surveys, EVERA enables dialogue: ask about childhood, principles,
-            decisive moments, or family history and receive answers grounded in real speech, semantic clusters, and
-            verified facts. It is a digitised personality that respects context and boundaries.</p>
-        </div>
-      </article>
+      
     </section>
 
     <!-- Процесс: 3 шага. Используются блоки step. -->
     <section id="process" class="section">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="container reveal stack">
           <div class="kicker">Процесс</div>
           <h2>Как это работает</h2>
@@ -306,59 +227,16 @@
             </div>
           </div>
           <div class="section-cta">
-            <a class="btn ghost" href="pages/methodology.html" data-href-ru="pages/methodology.html" data-href-en="pages/methodology.html?lang=en">Подробнее о методологии</a>
+            <a class="btn ghost" href="pages/methodology.html">Подробнее о методологии</a>
           </div>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="container reveal stack">
-          <div class="kicker">Process</div>
-          <h2>How it works</h2>
-          <p class="sub">Interview → Analytics → Dialogue. Respectful, transparent, without mysticism.</p>
-          <div class="process reveal-stagger">
-            <div class="step">
-              <div class="step-icon">
-                <img src="/assets/icons/interview.svg" alt="" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Ccircle%20cx%3D%2212%22%20cy%3D%229%22%20r%3D%224%22/%3E%3Cpath%20d%3D%22M8%2015c0%202.209%201.791%204%204%204s4-1.791%204-4%22/%3E%3Cpath%20d%3D%22M5%205l2.5%202.5M19%205l-2.5%202.5%22/%3E%3C/svg%3E';">
-              </div>
-              <div class="step-content">
-                <b>Interviews: 150+ prompts</b><br>
-                Childhood, family, genealogy, education, work, passions, ethical choices, and philosophy. Sessions are
-                flexible — remote or on-site, one-to-one or with relatives. The script adapts to reveal sensory
-                details, speech habits, and signature turns of phrase.
-              </div>
-            </div>
-            <div class="step">
-              <div class="step-icon">
-                <img src="/assets/icons/analysis.svg" alt="" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22M4%2015l4-4%203%203%205-5%204%204%22/%3E%3Cpath%20d%3D%22M4%204h16v16H4z%22/%3E%3C/svg%3E';">
-              </div>
-              <div class="step-content">
-                <b>Analytics: lexicon, emotion, structure</b><br>
-                Audio is transcribed, segmented, and cleaned. Stories are clustered, episodes and characters are
-                tagged, lexical profiles and emotional tones are highlighted. A memory graph emerges: a map of plots,
-                people, places, and motives.
-              </div>
-            </div>
-            <div class="step">
-              <div class="step-icon">
-                <img src="/assets/icons/dialog.svg" alt="" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22M5%205h14v8H9l-4%204z%22/%3E%3Cpath%20d%3D%22M9%2015v4l4-4h6v4l-4%204v-4H9z%22/%3E%3C/svg%3E';">
-              </div>
-              <div class="step-content">
-                <b>Dialogue layer: voice, style, access</b><br>
-                A cognitive model shapes a virtual companion who replies in the original cadence, cites sources, and
-                clarifies origins. Access can be configured from a private family circle to the public Eternals Library.
-              </div>
-            </div>
-          </div>
-          <div class="section-cta">
-            <a class="btn ghost" href="pages/methodology.html" data-href-ru="pages/methodology.html" data-href-en="pages/methodology.html?lang=en">Discover the methodology</a>
-          </div>
-        </div>
-      </article>
+      
     </section>
 
     <!-- ИИ модуль -->
     <section id="ai" class="section">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="container reveal stack">
           <div class="kicker">ИИ</div>
           <h2>ИИ «Архитектор вечности»</h2>
@@ -369,21 +247,12 @@
             фильтры.</p>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="container reveal stack">
-          <div class="kicker">AI</div>
-          <h2>AI “Architect of Eternity”</h2>
-          <p>Our custom AI module highlights episodes, builds a narrative map, finds lexical patterns, tracks emotional
-            dynamics, and helps structure the Book of Life. It never invents facts — it works strictly with verified
-            sources: interviews, documents, and artefacts. An expert editorial layer supervises the model: identity
-            verification, ambiguity editing, and ethical safeguards.</p>
-        </div>
-      </article>
+      
     </section>
 
     <!-- Книга Жизни -->
     <section id="book" class="section">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="container reveal stack">
           <div class="kicker">Издание</div>
           <h2>«Книга Жизни»</h2>
@@ -392,28 +261,16 @@
             веб‑изданием с расширенным поиском и оглавлением. Редакция аккуратно собирает голосовой портрет:
             характерные слова и интонации становятся навигацией по смыслу.</p>
           <div class="section-cta">
-            <a class="btn ghost" href="pages/book.html" data-href-ru="pages/book.html" data-href-en="pages/book.html?lang=en">Подробнее о Книге Жизни</a>
+            <a class="btn ghost" href="pages/book.html">Подробнее о Книге Жизни</a>
           </div>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="container reveal stack">
-          <div class="kicker">Edition</div>
-          <h2>Book of Life</h2>
-          <p>The Book of Life is a crafted biographical chronicle: era-based chapters, themes, quotes, photography,
-            timelines, and QR codes leading to audio and video fragments. The edition can be printed, an interactive
-            PDF, or a web volume with advanced search and navigation. Editors assemble the vocal portrait with care so
-            signature words and intonations guide the meaning.</p>
-          <div class="section-cta">
-            <a class="btn ghost" href="pages/book.html" data-href-ru="pages/book.html" data-href-en="pages/book.html?lang=en">Learn about the Book of Life</a>
-          </div>
-        </div>
-      </article>
+      
     </section>
 
     <!-- Библиотека Вечных -->
     <section id="eternals" class="section">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="container reveal stack">
           <div class="kicker">Образование</div>
           <h2>Библиотека «Вечных»</h2>
@@ -423,29 +280,16 @@
             как интерактивный учебник; семьи и фонды - как мемориальный ИИ‑архив: экспозиции, аудиогиды, тематические
             встречи.</p>
           <div class="section-cta">
-            <a class="btn ghost" href="pages/eternals.html" data-href-ru="pages/eternals.html" data-href-en="pages/eternals.html?lang=en">Открыть Библиотеку Вечных</a>
+            <a class="btn ghost" href="pages/eternals.html">Открыть Библиотеку Вечных</a>
           </div>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="container reveal stack">
-          <div class="kicker">Education</div>
-          <h2>Eternals Library</h2>
-          <p>The Eternals Library is a collection of public digital portraits of historical figures, patrons,
-            scientists, educators, and cultural leaders. It enables ethical educational dialogues: style is restored,
-            sources are cited, and reconstruction limits are highlighted. Teachers use the library as an interactive
-            textbook; families and foundations use it as a memorial AI archive for exhibitions, audio tours, and
-            themed gatherings.</p>
-          <div class="section-cta">
-            <a class="btn ghost" href="pages/eternals.html" data-href-ru="pages/eternals.html" data-href-en="pages/eternals.html?lang=en">Visit the Eternals Library</a>
-          </div>
-        </div>
-      </article>
+      
     </section>
 
     <!-- Для кого -->
     <section id="audience" class="section">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="container reveal stack">
           <div class="kicker">Целевая аудитория</div>
           <h2>Для кого это</h2>
@@ -457,23 +301,12 @@
             лингвистике и психологии. EVERA служит источником выверенных фактов и эмоциональных профилей.</p>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="container reveal stack">
-          <div class="kicker">Audience</div>
-          <h2>Who it is for</h2>
-          <p><strong>Families</strong> receive a digital legacy that unites generations: children hear familiar
-            intonations, learn family recipes and principles, and comprehend their heritage.</p>
-          <p><strong>Museums, archives, and educational projects</strong> create interactive cases: audio guides,
-            exhibitions, history and literature lessons, dialogues with sources.</p>
-          <p><strong>Researchers</strong> gain structured datasets for history, ethnography, linguistics, and psychology
-            projects. EVERA provides verified facts and emotional profiles.</p>
-        </div>
-      </article>
+      
     </section>
 
     <!-- Корпоративный блок -->
     <section id="b2b" class="section">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="container reveal stack">
           <div class="kicker">Корпорации</div>
           <h2>EVERA для бизнеса</h2>
@@ -496,47 +329,21 @@
             <p>Смотрите тарифы EVERA или получите индивидуальный расчёт - команда ответит на почту и в Telegram.</p>
             <div class="cta-actions">
               <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20-%20Запрос%20расчёта">Запросить расчёт</a>
-              <a class="btn" href="pages/pricing.html" data-href-ru="pages/pricing.html" data-href-en="pages/pricing.html?lang=en">Все тарифы</a>
+              <a class="btn" href="pages/pricing.html">Все тарифы</a>
               <a class="btn ghost" href="https://t.me/Solo013" target="_blank" rel="noopener">Telegram</a>
             </div>
             <div class="section-cta">
-              <a class="btn ghost" href="pages/b2b.html" data-href-ru="pages/b2b.html" data-href-en="pages/b2b.html?lang=en">Подробнее о решениях для бизнеса</a>
+              <a class="btn ghost" href="pages/b2b.html">Подробнее о решениях для бизнеса</a>
             </div>
           </div>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="container reveal stack">
-          <div class="kicker">Corporate</div>
-          <h2>EVERA for business</h2>
-          <p>Corporate memory that actually works. EVERA helps companies create a digital brand presence and digitise
-            leaders: voice, values, management principles, decision cases. It is not a PR bot but a verifiable
-            cognitive knowledge base accessible to employees, partners, and media under clear rules.</p>
-          <ul class="business-list reveal-stagger">
-            <li><strong>Unified brand voice</strong>: consistent answers and tone for the website, press kit, and service scenarios.</li>
-            <li><strong>Operational knowledge</strong>: conversational access to cases, playbooks, product history, and sales narratives.</li>
-            <li><strong>Succession of leadership</strong>: transfer management approaches and principles to new teams.</li>
-            <li><strong>Onboarding</strong>: immerse newcomers quickly through dialogues with company and leadership portraits.</li>
-            <li><strong>CSR and employer brand</strong>: public editions for careers, educational partnerships, and media.</li>
-          </ul>
-          <div class="cta-block">
-            <p>Explore EVERA plans or request a tailored quote — the team replies via email or Telegram.</p>
-            <div class="cta-actions">
-              <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20-%20Request%20a%20quote">Request a quote</a>
-              <a class="btn" href="pages/pricing.html" data-href-ru="pages/pricing.html" data-href-en="pages/pricing.html?lang=en">View all plans</a>
-              <a class="btn ghost" href="https://t.me/Solo013" target="_blank" rel="noopener">Telegram</a>
-            </div>
-            <div class="section-cta">
-              <a class="btn ghost" href="pages/b2b.html" data-href-ru="pages/b2b.html" data-href-en="pages/b2b.html?lang=en">Learn about B2B solutions</a>
-            </div>
-          </div>
-        </div>
-      </article>
+      
     </section>
 
     <!-- Бзопасность и этика -->
     <section id="ethics" class="section">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="container reveal stack">
           <div class="kicker">Этика</div>
           <h2>Безопасность и этика</h2>
@@ -549,23 +356,12 @@
             осторожность и приоритет желания семьи.</p>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="container reveal stack">
-          <div class="kicker">Ethics</div>
-          <h2>Security and ethics</h2>
-          <p><strong>Data treated as sacred.</strong> All personal data is encrypted; access is configured via family roles
-            (family admin, editor, reader). We record family consent, document transparent data use, host it on reliable
-            infrastructure, and provide flexible access tiers.</p>
-          <p><strong>Ethical principles.</strong> Respect for memory and personal autonomy, transparency of methods,
-            a clear separation of facts from interpretations, and labelling of reconstructed fragments. Sensitive
-            topics are handled with caution and the family’s wishes take priority.</p>
-        </div>
-      </article>
+      
     </section>
 
     <!-- Отзывы -->
     <section id="reviews" class="section">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="container reveal stack">
           <div class="kicker">Отзывы</div>
           <h2>Отзывы</h2>
@@ -580,25 +376,12 @@
           </div>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="container reveal stack">
-          <div class="kicker">Testimonials</div>
-          <h2>Testimonials</h2>
-          <div class="reviews-grid reveal-stagger">
-            <div class="review">
-              “We heard our grandfather again. His favourite expressions and pauses — as if we were back in the kitchen together.” — Maria K.
-            </div>
-            <div class="review">
-              “For a school project we interviewed the portrait of our teacher and unpacked his decisions from the toughest years.” — Pavel N.
-            </div>
-          </div>
-        </div>
-      </article>
+      
     </section>
 
     <!-- FAQ -->
     <section id="faq" class="section">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="container reveal stack">
           <div class="kicker">FAQ</div>
           <h2>Частые вопросы</h2>
@@ -634,45 +417,12 @@
           </details>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="container reveal stack">
-          <div class="kicker">FAQ</div>
-          <h2>Frequently asked questions</h2>
-          <details open>
-            <summary>What is digital immortality?</summary>
-            <p>It is the digitisation of a personality — not only facts but also speech, values, and emotional cues so
-              descendants can converse with their ancestors safely and ethically.</p>
-          </details>
-          <details>
-            <summary>How is the digital portrait created?</summary>
-            <p>Interviews (150+ prompts) → analytics (lexicon, emotions, clusters) → cognitive model →
-              virtual companion with configurable access.</p>
-          </details>
-          <details>
-            <summary>Can we digitise my parents’ memories?</summary>
-            <p>Yes. We help prepare questions, gather materials, run interviews, and configure family access.</p>
-          </details>
-          <details>
-            <summary>How is EVERA different from chatbots?</summary>
-            <p>It is grounded in real speech and biography with verification, source citations, and ethical filters. No
-              “made up” responses without clear labelling.</p>
-          </details>
-          <details>
-            <summary>How are my data protected?</summary>
-            <p>Encryption, family-controlled consent, secure infrastructure, an access broker, and an audit log.</p>
-          </details>
-          <details>
-            <summary>How long does the process take?</summary>
-            <p>First results appear right after interviews — a portrait preview and digest. The full Book of Life and
-              dialogue layer follow the agreed roadmap.</p>
-          </details>
-        </div>
-      </article>
+      
     </section>
 
     <!-- Финальный шаг и кнопка создания -->
     <section id="final" class="section">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="container reveal stack">
           <h2>Готовы сохранить память?</h2>
           <p>EVERA сохраняет то, что обычно ускользает: голос, смысл, связь. Создайте цифровое наследие, которое
@@ -683,32 +433,19 @@
           </div>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="container reveal stack">
-          <h2>Ready to preserve memory?</h2>
-          <p>EVERA keeps what usually slips away: voice, meaning, connection. Create a digital legacy that remains
-            accessible and comprehensible for future generations.</p>
-          <div class="cta stack">
-            <a class="btn" href="#" data-dialog-target="donateDialog">Support the project</a>
-            <a class="btn ghost" href="https://t.me/sololabschannel" target="_blank" rel="noopener">Schedule an interview</a>
-          </div>
-        </div>
-      </article>
+      
     </section>
 
     <!-- Donation modal (общий для всего сайта) -->
     <dialog id="donateDialog">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <h3>Поддержать EVERA</h3>
         <p class="small">Выберите сеть и скопируйте адрес для пожертвования.</p>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <h3>Support EVERA</h3>
-        <p class="small">Choose a network and copy the address for your donation.</p>
-      </article>
+      
       <label>
-        <span data-lang="ru" lang="ru">Сеть:</span>
-        <span data-lang="en" lang="en" hidden>Network:</span>
+        <span lang="ru">Сеть:</span>
+        
         <select id="donNetwork">
           <option value="usdt">USDT TRC20</option>
           <option value="ton">Toncoin (TON)</option>
@@ -717,18 +454,18 @@
         </select>
       </label>
       <label>
-        <span data-lang="ru" lang="ru">Адрес:</span>
-        <span data-lang="en" lang="en" hidden>Address:</span>
+        <span lang="ru">Адрес:</span>
+        
         <input type="text" id="donAddress" readonly>
       </label>
       <div class="modal-actions">
         <button id="copyAddr" class="btn ghost" type="button">
-          <span data-lang="ru" lang="ru">Копировать</span>
-          <span data-lang="en" lang="en" hidden>Copy</span>
+          <span lang="ru">Копировать</span>
+          
         </button>
         <button id="closeDonate" class="btn" type="button">
-          <span data-lang="ru" lang="ru">Закрыть</span>
-          <span data-lang="en" lang="en" hidden>Close</span>
+          <span lang="ru">Закрыть</span>
+          
         </button>
       </div>
     </dialog>
@@ -736,7 +473,7 @@
 
   <!-- Подвал -->
   <footer class="footer">
-    <article data-lang="ru" lang="ru">
+    <article lang="ru">
       <div class="container">
         <div class="footer-grid">
           <div class="footer-brand">
@@ -757,11 +494,11 @@
           <div class="footer-col">
             <h3>Страницы</h3>
             <ul>
-              <li><a href="pages/methodology.html" data-href-ru="pages/methodology.html" data-href-en="pages/methodology.html?lang=en">Методология EVERA</a></li>
-              <li><a href="pages/book.html" data-href-ru="pages/book.html" data-href-en="pages/book.html?lang=en">Книга Жизни</a></li>
-              <li><a href="pages/eternals.html" data-href-ru="pages/eternals.html" data-href-en="pages/eternals.html?lang=en">Библиотека «Вечных»</a></li>
-              <li><a href="pages/b2b.html" data-href-ru="pages/b2b.html" data-href-en="pages/b2b.html?lang=en">Решения для бизнеса</a></li>
-              <li><a href="pages/pricing.html" data-href-ru="pages/pricing.html" data-href-en="pages/pricing.html?lang=en">Все тарифы</a></li>
+              <li><a href="pages/methodology.html">Методология EVERA</a></li>
+              <li><a href="pages/book.html">Книга Жизни</a></li>
+              <li><a href="pages/eternals.html">Библиотека «Вечных»</a></li>
+              <li><a href="pages/b2b.html">Решения для бизнеса</a></li>
+              <li><a href="pages/pricing.html">Все тарифы</a></li>
             </ul>
           </div>
           <div class="footer-col">
@@ -769,57 +506,16 @@
             <ul>
               <li><a href="/sitemap.xml">Карта сайта</a></li>
               <li><a href="/robots.txt">robots.txt</a></li>
-              <li><a href="pages/team.html" data-href-ru="pages/team.html" data-href-en="pages/team.html?lang=en">Команда</a></li>
-              <li><a href="pages/roadmap.html" data-href-ru="pages/roadmap.html" data-href-en="pages/roadmap.html?lang=en">Дорожная карта</a></li>
-              <li><a href="pages/cases.html" data-href-ru="pages/cases.html" data-href-en="pages/cases.html?lang=en">Кейсы</a></li>
+              <li><a href="pages/team.html">Команда</a></li>
+              <li><a href="pages/roadmap.html">Дорожная карта</a></li>
+              <li><a href="pages/cases.html">Кейсы</a></li>
             </ul>
           </div>
         </div>
         <div class="copy">© 2025 EVERA · No ads · No trackers</div>
       </div>
     </article>
-    <article data-lang="en" lang="en" hidden>
-      <div class="container">
-        <div class="footer-grid">
-          <div class="footer-brand">
-            <a class="logo" href="#mission" aria-label="EVERA"><img src="evera-logo-white.svg" alt="EVERA"></a>
-            <p class="small">EVERA — digital immortality and a living dialogue across generations.</p>
-            <p class="small">Contact: <a href="mailto:hello@evera.world">hello@evera.world</a><br><a href="https://t.me/Solo013" target="_blank" rel="noopener">t.me/Solo013</a></p>
-          </div>
-          <div class="footer-col">
-            <h3>Navigation</h3>
-            <ul>
-              <li><a href="#what">What is EVERA</a></li>
-              <li><a href="#process">Methodology</a></li>
-              <li><a href="#book">Book of Life</a></li>
-              <li><a href="#eternals">Eternals Library</a></li>
-              <li><a href="#b2b">Business solutions</a></li>
-            </ul>
-          </div>
-          <div class="footer-col">
-            <h3>Pages</h3>
-            <ul>
-              <li><a href="pages/methodology.html" data-href-ru="pages/methodology.html" data-href-en="pages/methodology.html?lang=en">Methodology</a></li>
-              <li><a href="pages/book.html" data-href-ru="pages/book.html" data-href-en="pages/book.html?lang=en">Book of Life</a></li>
-              <li><a href="pages/eternals.html" data-href-ru="pages/eternals.html" data-href-en="pages/eternals.html?lang=en">Eternals Library</a></li>
-              <li><a href="pages/b2b.html" data-href-ru="pages/b2b.html" data-href-en="pages/b2b.html?lang=en">B2B solutions</a></li>
-              <li><a href="pages/pricing.html" data-href-ru="pages/pricing.html" data-href-en="pages/pricing.html?lang=en">All plans</a></li>
-            </ul>
-          </div>
-          <div class="footer-col">
-            <h3>Resources</h3>
-            <ul>
-              <li><a href="/sitemap.xml">Sitemap</a></li>
-              <li><a href="/robots.txt">robots.txt</a></li>
-              <li><a href="pages/team.html" data-href-ru="pages/team.html" data-href-en="pages/team.html?lang=en">Team</a></li>
-              <li><a href="pages/roadmap.html" data-href-ru="pages/roadmap.html" data-href-en="pages/roadmap.html?lang=en">Roadmap</a></li>
-              <li><a href="pages/cases.html" data-href-ru="pages/cases.html" data-href-en="pages/cases.html?lang=en">Cases</a></li>
-            </ul>
-          </div>
-        </div>
-        <div class="copy">© 2025 EVERA · No ads · No trackers</div>
-      </div>
-    </article>
+    
   </footer>
 
   <!-- Главный скрипт: звёзды, модальное окно, reveal-анимации -->

--- a/pages/b2b.html
+++ b/pages/b2b.html
@@ -5,8 +5,8 @@
 <title>EVERA для бизнеса | корпоративная память и брендовые истории</title>
 <meta name="description" content="Решения EVERA для бизнеса: цифровой голос основателя, база знаний бренда, обучение и наследие руководителей. Узнайте о модулях, внедрении и тарифах.">
 <link rel="icon" href="/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/pages/b2b.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/pages/b2b.html?lang=en">
+<link rel="alternate" hreflang="ru" href="https://evera.world/b2b">
+<link rel="alternate" hreflang="en" href="https://evera.world/en/b2b">
 <link rel="canonical" href="https://evera.world/b2b">
 <link rel="stylesheet" href="/css/styles.css">
 </head>
@@ -19,9 +19,9 @@
     <a class="logo" href="../index.html#mission" aria-label="EVERA">
       <img src="../evera-logo-white.svg" alt="EVERA logo">
     </a>
-    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню / Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню" aria-expanded="false" aria-controls="navDrawer">☰</button>
     <nav class="links" id="primaryNav" aria-label="Основная навигация">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="menu-group" aria-label="Навигация по разделам страницы">
           <a href="../index.html#mission">Главная</a>
           <a href="../index.html#what">Что такое</a>
@@ -35,24 +35,11 @@
           <a href="../index.html#faq">FAQ</a>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="menu-group" aria-label="Navigate page sections">
-          <a href="../index.html#mission">Home</a>
-          <a href="../index.html#what">What</a>
-          <a href="../index.html#process">Process</a>
-          <a href="../index.html#ai">AI</a>
-          <a href="../index.html#book">Book of Life</a>
-          <a href="../index.html#eternals">Eternals</a>
-          <a href="../index.html#audience">Audience</a>
-          <a href="../index.html#b2b">Business</a>
-          <a href="../index.html#ethics">Ethics</a>
-          <a href="../index.html#faq">FAQ</a>
-        </div>
-      </article>
+      
     </nav>
-    <select class="lang-switch" aria-label="Switch language">
-      <option value="ru">RU</option>
-      <option value="en">EN</option>
+    <select class="lang-switch" aria-label="Переключить язык">
+      <option value="ru" data-url="/pages/b2b.html" selected>RU</option>
+      <option value="en" data-url="/en/pages/b2b.html">EN</option>
     </select>
   </div>
 </header>
@@ -60,14 +47,14 @@
 <aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
   <div class="nav-drawer__header">
     <h2 id="menuTitle">
-      <span data-lang="ru" lang="ru">Меню</span>
-      <span data-lang="en" lang="en" hidden>Menu</span>
+      <span lang="ru">Меню</span>
+      
     </h2>
-    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню / Close menu">✕</button>
+    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню">✕</button>
   </div>
 
   <nav class="nav-drawer__body stack" aria-label="Навигация по сайту">
-    <article data-lang="ru" lang="ru" class="stack">
+    <article lang="ru" class="stack">
       <div class="drawer-group stack">
         <div class="drawer-title">Разделы</div>
         <a href="../index.html#mission">Главная</a>
@@ -84,57 +71,31 @@
 
       <div class="drawer-group stack">
         <div class="drawer-title">Страницы</div>
-        <a href="pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Тарифы</a>
-        <a href="methodology.html" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Методология</a>
-        <a href="book.html" data-href-ru="book.html" data-href-en="book.html?lang=en">Издание «Книга Жизни»</a>
-        <a href="eternals.html" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Библиотека «Вечных»</a>
-        <a href="b2b.html" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en" class="active">Корпоративные решения</a>
-        <a href="cases.html" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Кейсы</a>
-        <a href="team.html" data-href-ru="team.html" data-href-en="team.html?lang=en">Команда</a>
-        <a href="roadmap.html" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Роадмап</a>
+        <a href="pricing.html">Тарифы</a>
+        <a href="methodology.html">Методология</a>
+        <a href="book.html">Издание «Книга Жизни»</a>
+        <a href="eternals.html">Библиотека «Вечных»</a>
+        <a href="b2b.html" class="active">Корпоративные решения</a>
+        <a href="cases.html">Кейсы</a>
+        <a href="team.html">Команда</a>
+        <a href="roadmap.html">Роадмап</a>
       </div>
     </article>
 
-    <article data-lang="en" lang="en" class="stack" hidden>
-      <div class="drawer-group stack">
-        <div class="drawer-title">Sections</div>
-        <a href="../index.html#mission">Home</a>
-        <a href="../index.html#what">What</a>
-        <a href="../index.html#process">Process</a>
-        <a href="../index.html#ai">AI</a>
-        <a href="../index.html#book">Book of Life</a>
-        <a href="../index.html#eternals">Eternals</a>
-        <a href="../index.html#audience">Audience</a>
-        <a href="../index.html#b2b">Business</a>
-        <a href="../index.html#ethics">Ethics</a>
-        <a href="../index.html#faq">FAQ</a>
-      </div>
-
-      <div class="drawer-group stack">
-        <div class="drawer-title">Pages</div>
-        <a href="../en/pages/pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Pricing</a>
-        <a href="methodology.html?lang=en" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Methodology</a>
-        <a href="book.html?lang=en" data-href-ru="book.html" data-href-en="book.html?lang=en">Book of Life</a>
-        <a href="eternals.html?lang=en" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Eternals Library</a>
-        <a href="b2b.html?lang=en" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en" class="active">B2B solutions</a>
-        <a href="cases.html?lang=en" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Cases</a>
-        <a href="team.html?lang=en" data-href-ru="team.html" data-href-en="team.html?lang=en">Team</a>
-        <a href="roadmap.html?lang=en" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Roadmap</a>
-      </div>
-    </article>
+    
   </nav>
   <div class="nav-drawer__footer">
     <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
       <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
     </a>
     <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
-      <span data-lang="ru" lang="ru">Telegram-канал</span>
-      <span data-lang="en" lang="en" hidden>Telegram channel</span>
+      <span lang="ru">Telegram-канал</span>
+      
     </a>
   </div>
 </aside>
 <main>
-  <article class="page-intro" data-lang="ru" lang="ru">
+  <article class="page-intro" lang="ru">
     <section class="section">
       <div class="container">
         <h1>EVERA для бизнеса</h1>
@@ -225,111 +186,14 @@
           <p>Посмотрите тарифы EVERA и обсудите индивидуальный расчёт для вашей команды.</p>
           <div class="cta-actions">
             <a class="btn" href="mailto:b2b@evera.world?subject=EVERA%20B2B%20-%20Запрос%20расчёта">Запросить расчёт</a>
-            <a class="btn" href="/pages/pricing.html" data-href-ru="/pages/pricing.html" data-href-en="/en/pages/pricing.html">Тарифы EVERA</a>
+            <a class="btn" href="/pages/pricing.html">Тарифы EVERA</a>
             <a class="btn ghost" href="https://t.me/Solo013" target="_blank" rel="noopener">Telegram</a>
           </div>
         </div>
       </div>
     </section>
   </article>
-  <article class="page-intro" data-lang="en" lang="en" hidden>
-    <section class="section">
-      <div class="container">
-        <h1>EVERA for Business</h1>
-        <p class="lead">We build corporate memory: the founder’s voice, case library, onboarding scenarios, and PR support. Your brand receives a conversational partner that speaks in your company’s tone.</p>
-        <div class="pill-list"><span>Legacy</span><span>Learning</span><span>PR</span><span>Investors</span></div>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Use cases</div>
-        <h2>Business challenges we solve</h2>
-        <div class="cards-grid">
-          <div class="card">
-            <h3>Onboarding</h3>
-            <p>New hires explore company history, values, and landmark decisions through dialogue and real stories.</p>
-          </div>
-          <div class="card">
-            <h3>Public communications</h3>
-            <p>A consistent brand voice for media, partners, and conferences with answers backed by verified sources.</p>
-          </div>
-          <div class="card">
-            <h3>Investor relations</h3>
-            <p>Instant responses about product economics, strategy, and leadership principles.</p>
-          </div>
-          <div class="card">
-            <h3>Leadership legacy</h3>
-            <p>Preserves founders’ philosophy and management practices as part of the corporate university.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Modules</div>
-        <h2>Product configuration</h2>
-        <div class="two-column">
-          <div>
-            <h3>Brand dialogue AI</h3>
-            <p>The trained model speaks with the leadership voice, cites documents, and logs user feedback automatically.</p>
-            <ul>
-              <li>Modes: PR, HR, Investors.</li>
-              <li>Integrations with Slack, Teams, and internal portals.</li>
-            </ul>
-          </div>
-          <div>
-            <h3>Decision archive</h3>
-            <p>Structured cases and regulations available via search and thematic maps.</p>
-            <ul>
-              <li>Dedicated views for employees and authorised partners.</li>
-              <li>Automatic updates after every new interview cycle.</li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Implementation</div>
-        <h2>Launch phases</h2>
-        <ul class="timeline">
-          <li><strong>Diagnosis.</strong> Align goals, KPIs, and team composition.</li>
-          <li><strong>Interviews &amp; data.</strong> In-depth interviews with founders and key teams plus content audit.</li>
-          <li><strong>Knowledge base.</strong> Analytics, structuring, and access configuration.</li>
-          <li><strong>Go-live &amp; training.</strong> Pilot sessions, employee workshops, and feedback loop.</li>
-          <li><strong>Support.</strong> Quarterly updates, quality assurance, and scenario expansion.</li>
-        </ul>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Plans</div>
-        <h2>Partnership packages</h2>
-        <div class="table-like">
-          <div class="row">
-            <h3>Start</h3>
-            <p>One key leader, three interviews, core dialogue module, six-week launch.</p>
-          </div>
-          <div class="row">
-            <h3>Scale</h3>
-            <p>Three to five leaders, corporate decision archive, HR system integration, six-month support.</p>
-          </div>
-          <div class="row">
-            <h3>Enterprise</h3>
-            <p>Multi-office deployment, SLA, custom scenarios, and in-house curator training.</p>
-          </div>
-        </div>
-        <div class="cta-block">
-          <p>Explore EVERA pricing or reach out for a bespoke scope tailored to your organisation.</p>
-          <div class="cta-actions">
-            <a class="btn" href="mailto:b2b@evera.world?subject=EVERA%20B2B%20-%20Request%20a%20quote">Request a quote</a>
-            <a class="btn" href="/en/pages/pricing.html">EVERA Pricing</a>
-            <a class="btn ghost" href="https://t.me/Solo013" target="_blank" rel="noopener">Telegram</a>
-          </div>
-        </div>
-      </div>
-    </section>
-  </article>
+  
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/js/app.js"></script>

--- a/pages/book.html
+++ b/pages/book.html
@@ -5,8 +5,8 @@
 <title>Книга Жизни | издание EVERA</title>
 <meta name="description" content="Книга Жизни EVERA: структурированная биография с голосами, фотографиями и интерактивными QR-ссылками. Узнайте, как мы создаём издание и какие форматы доступны.">
 <link rel="icon" href="/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/pages/book.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/pages/book.html?lang=en">
+<link rel="alternate" hreflang="ru" href="https://evera.world/book">
+<link rel="alternate" hreflang="en" href="https://evera.world/en/book">
 <link rel="canonical" href="https://evera.world/book">
 <link rel="stylesheet" href="/css/styles.css">
 </head>
@@ -19,9 +19,9 @@
     <a class="logo" href="../index.html#mission" aria-label="EVERA">
       <img src="../evera-logo-white.svg" alt="EVERA logo">
     </a>
-    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню / Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню" aria-expanded="false" aria-controls="navDrawer">☰</button>
     <nav class="links" id="primaryNav" aria-label="Основная навигация">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="menu-group" aria-label="Навигация по разделам страницы">
           <a href="../index.html#mission">Главная</a>
           <a href="../index.html#what">Что такое</a>
@@ -35,24 +35,11 @@
           <a href="../index.html#faq">FAQ</a>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="menu-group" aria-label="Navigate page sections">
-          <a href="../index.html#mission">Home</a>
-          <a href="../index.html#what">What</a>
-          <a href="../index.html#process">Process</a>
-          <a href="../index.html#ai">AI</a>
-          <a href="../index.html#book">Book of Life</a>
-          <a href="../index.html#eternals">Eternals</a>
-          <a href="../index.html#audience">Audience</a>
-          <a href="../index.html#b2b">Business</a>
-          <a href="../index.html#ethics">Ethics</a>
-          <a href="../index.html#faq">FAQ</a>
-        </div>
-      </article>
+      
     </nav>
-    <select class="lang-switch" aria-label="Switch language">
-      <option value="ru">RU</option>
-      <option value="en">EN</option>
+    <select class="lang-switch" aria-label="Переключить язык">
+      <option value="ru" data-url="/pages/book.html" selected>RU</option>
+      <option value="en" data-url="/en/pages/book.html">EN</option>
     </select>
   </div>
 </header>
@@ -60,14 +47,14 @@
 <aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
   <div class="nav-drawer__header">
     <h2 id="menuTitle">
-      <span data-lang="ru" lang="ru">Меню</span>
-      <span data-lang="en" lang="en" hidden>Menu</span>
+      <span lang="ru">Меню</span>
+      
     </h2>
-    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню / Close menu">✕</button>
+    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню">✕</button>
   </div>
 
   <nav class="nav-drawer__body stack" aria-label="Навигация по сайту">
-    <article data-lang="ru" lang="ru" class="stack">
+    <article lang="ru" class="stack">
       <div class="drawer-group stack">
         <div class="drawer-title">Разделы</div>
         <a href="../index.html#mission">Главная</a>
@@ -84,57 +71,31 @@
 
       <div class="drawer-group stack">
         <div class="drawer-title">Страницы</div>
-        <a href="pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Тарифы</a>
-        <a href="methodology.html" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Методология</a>
-        <a href="book.html" data-href-ru="book.html" data-href-en="book.html?lang=en" class="active">Издание «Книга Жизни»</a>
-        <a href="eternals.html" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Библиотека «Вечных»</a>
-        <a href="b2b.html" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">Корпоративные решения</a>
-        <a href="cases.html" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Кейсы</a>
-        <a href="team.html" data-href-ru="team.html" data-href-en="team.html?lang=en">Команда</a>
-        <a href="roadmap.html" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Роадмап</a>
+        <a href="pricing.html">Тарифы</a>
+        <a href="methodology.html">Методология</a>
+        <a href="book.html" class="active">Издание «Книга Жизни»</a>
+        <a href="eternals.html">Библиотека «Вечных»</a>
+        <a href="b2b.html">Корпоративные решения</a>
+        <a href="cases.html">Кейсы</a>
+        <a href="team.html">Команда</a>
+        <a href="roadmap.html">Роадмап</a>
       </div>
     </article>
 
-    <article data-lang="en" lang="en" class="stack" hidden>
-      <div class="drawer-group stack">
-        <div class="drawer-title">Sections</div>
-        <a href="../index.html#mission">Home</a>
-        <a href="../index.html#what">What</a>
-        <a href="../index.html#process">Process</a>
-        <a href="../index.html#ai">AI</a>
-        <a href="../index.html#book">Book of Life</a>
-        <a href="../index.html#eternals">Eternals</a>
-        <a href="../index.html#audience">Audience</a>
-        <a href="../index.html#b2b">Business</a>
-        <a href="../index.html#ethics">Ethics</a>
-        <a href="../index.html#faq">FAQ</a>
-      </div>
-
-      <div class="drawer-group stack">
-        <div class="drawer-title">Pages</div>
-        <a href="../en/pages/pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Pricing</a>
-        <a href="methodology.html?lang=en" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Methodology</a>
-        <a href="book.html?lang=en" data-href-ru="book.html" data-href-en="book.html?lang=en" class="active">Book of Life</a>
-        <a href="eternals.html?lang=en" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Eternals Library</a>
-        <a href="b2b.html?lang=en" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">B2B solutions</a>
-        <a href="cases.html?lang=en" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Cases</a>
-        <a href="team.html?lang=en" data-href-ru="team.html" data-href-en="team.html?lang=en">Team</a>
-        <a href="roadmap.html?lang=en" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Roadmap</a>
-      </div>
-    </article>
+    
   </nav>
   <div class="nav-drawer__footer">
     <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
       <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
     </a>
     <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
-      <span data-lang="ru" lang="ru">Telegram-канал</span>
-      <span data-lang="en" lang="en" hidden>Telegram channel</span>
+      <span lang="ru">Telegram-канал</span>
+      
     </a>
   </div>
 </aside>
 <main>
-  <article class="page-intro" data-lang="ru" lang="ru">
+  <article class="page-intro" lang="ru">
     <section class="section">
       <div class="container">
         <h1>Книга Жизни EVERA</h1>
@@ -205,77 +166,7 @@
       </div>
     </section>
   </article>
-  <article class="page-intro" data-lang="en" lang="en" hidden>
-    <section class="section">
-      <div class="container">
-        <h1>EVERA Book of Life</h1>
-        <p class="lead">A signature edition that combines biographical chapters, quotations, photographs, and audio fragments. It is more than a family chronicle - it is a navigation system for memory.</p>
-        <div class="pill-list"><span>Voices</span><span>Photo archive</span><span>Quotes</span><span>QR links</span></div>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Highlights</div>
-        <h2>What the edition includes</h2>
-        <div class="cards-grid">
-          <div class="card">
-            <h3>Structure &amp; chapters</h3>
-            <p>The story unfolds by eras: childhood, turning points, legacy. Each chapter closes with insights and key values.</p>
-          </div>
-          <div class="card">
-            <h3>Voices &amp; emotions</h3>
-            <p>QR codes lead to audio and video. Loved ones hear the intonation, pauses, and laughter that text alone cannot carry.</p>
-          </div>
-          <div class="card">
-            <h3>Visual narrative</h3>
-            <p>We digitise photos, letters, and documents. Designers create collages, maps, and family trees.</p>
-          </div>
-          <div class="card">
-            <h3>Meaningful navigation</h3>
-            <p>Cross-links guide the reader to themes such as “Teaching”, “Travel”, “Family values”. Every story has a context.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Process</div>
-        <h2>How we craft the book</h2>
-        <ul class="timeline">
-          <li><strong>Gathering materials.</strong> Interviews, archives, letters. A curator helps prioritise stories.</li>
-          <li><strong>Editorial scripting.</strong> The editor shapes chapters, builds dramaturgy, and selects quotations.</li>
-          <li><strong>Design &amp; layout.</strong> Visual concept with palette, typography, and bespoke illustrations.</li>
-          <li><strong>Prototype review.</strong> The family receives a digital mockup, comments, and approves changes.</li>
-          <li><strong>Print &amp; digital delivery.</strong> Premium print run, interactive PDF, and upload to the family portal.</li>
-        </ul>
-        <p class="quote">“The Book of Life reminds us why our family exists. It’s not an album, it’s a living dialogue.” - Natalia, EVERA client.</p>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Formats</div>
-        <h2>Edition options</h2>
-        <div class="table-like">
-          <div class="row">
-            <h3>Premium print</h3>
-            <p>Hardcover, silk ribbon, art paper. Delivered in a gift box with QR companion cards.</p>
-          </div>
-          <div class="row">
-            <h3>Interactive PDF</h3>
-            <p>Hyperlinked edition with embedded audio players and family-friendly commenting.</p>
-          </div>
-          <div class="row">
-            <h3>Web edition</h3>
-            <p>Private website with thematic search, extended gallery, and dialogue AI integration.</p>
-          </div>
-        </div>
-        <div class="cta-block">
-          <p>Tell us who will receive the Book of Life and we will recommend the best format and prepare a demo excerpt.</p>
-          <a class="btn" href="mailto:book@evera.world">Request a consultation</a>
-        </div>
-      </div>
-    </section>
-  </article>
+  
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/js/app.js"></script>

--- a/pages/cases.html
+++ b/pages/cases.html
@@ -5,8 +5,8 @@
 <title>Кейсы EVERA | цифровые биографии для семей, музеев и бизнеса</title>
 <meta name="description" content="Реализованные кейсы EVERA: семейные архивы, музеи, корпоративные лидеры. Узнайте, какие задачи решает цифровая биография и как выглядит результат на русском и английском языках.">
 <link rel="icon" href="/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/pages/cases.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/pages/cases.html?lang=en">
+<link rel="alternate" hreflang="ru" href="https://evera.world/cases">
+<link rel="alternate" hreflang="en" href="https://evera.world/en/cases">
 <link rel="canonical" href="https://evera.world/cases">
 <link rel="stylesheet" href="/css/styles.css">
 </head>
@@ -19,9 +19,9 @@
     <a class="logo" href="../index.html#mission" aria-label="EVERA">
       <img src="../evera-logo-white.svg" alt="EVERA logo">
     </a>
-    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню / Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню" aria-expanded="false" aria-controls="navDrawer">☰</button>
     <nav class="links" id="primaryNav" aria-label="Основная навигация">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="menu-group" aria-label="Навигация по разделам страницы">
           <a href="../index.html#mission">Главная</a>
           <a href="../index.html#what">Что такое</a>
@@ -35,24 +35,11 @@
           <a href="../index.html#faq">FAQ</a>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="menu-group" aria-label="Navigate page sections">
-          <a href="../index.html#mission">Home</a>
-          <a href="../index.html#what">What</a>
-          <a href="../index.html#process">Process</a>
-          <a href="../index.html#ai">AI</a>
-          <a href="../index.html#book">Book of Life</a>
-          <a href="../index.html#eternals">Eternals</a>
-          <a href="../index.html#audience">Audience</a>
-          <a href="../index.html#b2b">Business</a>
-          <a href="../index.html#ethics">Ethics</a>
-          <a href="../index.html#faq">FAQ</a>
-        </div>
-      </article>
+      
     </nav>
-    <select class="lang-switch" aria-label="Switch language">
-      <option value="ru">RU</option>
-      <option value="en">EN</option>
+    <select class="lang-switch" aria-label="Переключить язык">
+      <option value="ru" data-url="/pages/cases.html" selected>RU</option>
+      <option value="en" data-url="/en/pages/cases.html">EN</option>
     </select>
   </div>
 </header>
@@ -60,14 +47,14 @@
 <aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
   <div class="nav-drawer__header">
     <h2 id="menuTitle">
-      <span data-lang="ru" lang="ru">Меню</span>
-      <span data-lang="en" lang="en" hidden>Menu</span>
+      <span lang="ru">Меню</span>
+      
     </h2>
-    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню / Close menu">✕</button>
+    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню">✕</button>
   </div>
 
   <nav class="nav-drawer__body stack" aria-label="Навигация по сайту">
-    <article data-lang="ru" lang="ru" class="stack">
+    <article lang="ru" class="stack">
       <div class="drawer-group stack">
         <div class="drawer-title">Разделы</div>
         <a href="../index.html#mission">Главная</a>
@@ -84,57 +71,31 @@
 
       <div class="drawer-group stack">
         <div class="drawer-title">Страницы</div>
-        <a href="pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Тарифы</a>
-        <a href="methodology.html" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Методология</a>
-        <a href="book.html" data-href-ru="book.html" data-href-en="book.html?lang=en">Издание «Книга Жизни»</a>
-        <a href="eternals.html" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Библиотека «Вечных»</a>
-        <a href="b2b.html" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">Корпоративные решения</a>
-        <a href="cases.html" data-href-ru="cases.html" data-href-en="cases.html?lang=en" class="active">Кейсы</a>
-        <a href="team.html" data-href-ru="team.html" data-href-en="team.html?lang=en">Команда</a>
-        <a href="roadmap.html" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Роадмап</a>
+        <a href="pricing.html">Тарифы</a>
+        <a href="methodology.html">Методология</a>
+        <a href="book.html">Издание «Книга Жизни»</a>
+        <a href="eternals.html">Библиотека «Вечных»</a>
+        <a href="b2b.html">Корпоративные решения</a>
+        <a href="cases.html" class="active">Кейсы</a>
+        <a href="team.html">Команда</a>
+        <a href="roadmap.html">Роадмап</a>
       </div>
     </article>
 
-    <article data-lang="en" lang="en" class="stack" hidden>
-      <div class="drawer-group stack">
-        <div class="drawer-title">Sections</div>
-        <a href="../index.html#mission">Home</a>
-        <a href="../index.html#what">What</a>
-        <a href="../index.html#process">Process</a>
-        <a href="../index.html#ai">AI</a>
-        <a href="../index.html#book">Book of Life</a>
-        <a href="../index.html#eternals">Eternals</a>
-        <a href="../index.html#audience">Audience</a>
-        <a href="../index.html#b2b">Business</a>
-        <a href="../index.html#ethics">Ethics</a>
-        <a href="../index.html#faq">FAQ</a>
-      </div>
-
-      <div class="drawer-group stack">
-        <div class="drawer-title">Pages</div>
-        <a href="../en/pages/pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Pricing</a>
-        <a href="methodology.html?lang=en" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Methodology</a>
-        <a href="book.html?lang=en" data-href-ru="book.html" data-href-en="book.html?lang=en">Book of Life</a>
-        <a href="eternals.html?lang=en" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Eternals Library</a>
-        <a href="b2b.html?lang=en" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">B2B solutions</a>
-        <a href="cases.html?lang=en" data-href-ru="cases.html" data-href-en="cases.html?lang=en" class="active">Cases</a>
-        <a href="team.html?lang=en" data-href-ru="team.html" data-href-en="team.html?lang=en">Team</a>
-        <a href="roadmap.html?lang=en" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Roadmap</a>
-      </div>
-    </article>
+    
   </nav>
   <div class="nav-drawer__footer">
     <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
       <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
     </a>
     <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
-      <span data-lang="ru" lang="ru">Telegram-канал</span>
-      <span data-lang="en" lang="en" hidden>Telegram channel</span>
+      <span lang="ru">Telegram-канал</span>
+      
     </a>
   </div>
 </aside>
 <main>
-  <article class="page-intro" data-lang="ru" lang="ru">
+  <article class="page-intro" lang="ru">
     <section class="section">
       <div class="container">
         <h1>Кейсы EVERA</h1>
@@ -202,74 +163,7 @@
       </div>
     </section>
   </article>
-  <article class="page-intro" data-lang="en" lang="en" hidden>
-    <section class="section">
-      <div class="container">
-        <h1>EVERA Case Studies</h1>
-        <p class="lead">We turn family archives, museum collections, and corporate knowledge into living dialogue experiences. Explore how the EVERA methodology adapts to different audiences.</p>
-        <div class="pill-list">
-          <span>Families</span><span>Museums</span><span>Education</span><span>Business</span>
-        </div>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Family heritage</div>
-        <h2>Portrait “The M. Family Voice”</h2>
-        <div class="two-column">
-          <div>
-            <p>A four-generation family from Saint Petersburg shared cassette tapes from the 1980s, letters, and a photo chronicle. We recorded fresh interviews, restored the vocal palette, and produced an interactive Book of Life with QR access to memories.</p>
-            <p class="quote">“Our kids hear their great-grandmother’s intonation. They don’t just read - they talk to her.” - project curator.</p>
-          </div>
-          <div class="stat-grid">
-            <div class="stat"><b>47</b>hours of interviews and transcripts</div>
-            <div class="stat"><b>320</b>archival photographs digitised and described</div>
-            <div class="stat"><b>18</b>family journeys mapped with audio guides</div>
-          </div>
-        </div>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Museums &amp; education</div>
-        <h2>Project “Talking Collections” for a city library</h2>
-        <div class="cards-grid">
-          <div class="card">
-            <h3>Challenge</h3>
-            <p>Create a dialogue-driven exhibition about local philanthropists and make the archive accessible for students and researchers.</p>
-          </div>
-          <div class="card">
-            <h3>Solution</h3>
-            <p>A series of interviews with descendants and experts, synchronised with artefacts, audio guide scripts, and AR markers.</p>
-          </div>
-          <div class="card">
-            <h3>Outcome</h3>
-            <p>An interactive exhibition and a public cabinet in the Eternals Library. Visitors ask the “digital heroes” questions and receive sourced answers.</p>
-          </div>
-          <div class="card">
-            <h3>Impact</h3>
-            <p>+62% exhibition attendance, 12 educational programs, 1.8K dialogues per month.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Corporate memory</div>
-        <h2>“Founder’s Voice” for a tech company</h2>
-        <p>The goal was to preserve leadership knowledge and onboard new executives faster. We interviewed the founder, top managers, and veteran employees, documenting key decisions, crisis playbooks, and the brand’s humour codes.</p>
-        <ul>
-          <li>Launched a dialogue assistant with dedicated modes: strategy sessions, onboarding, and investor Q&amp;A.</li>
-          <li>Produced quote collections and video cases for internal meetups.</li>
-          <li>Implemented an update protocol so fresh stories are verified and published automatically.</li>
-        </ul>
-        <div class="cta-block">
-          <p>Need a digital portrait for your family, foundation, or brand? Tell us about the challenge and we will recommend the best format.</p>
-          <a class="btn" href="mailto:projects@evera.world">Request a consultation</a>
-        </div>
-      </div>
-    </section>
-  </article>
+  
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/js/app.js"></script>

--- a/pages/eternals.html
+++ b/pages/eternals.html
@@ -5,8 +5,8 @@
 <title>Библиотека «Вечных» | публичные цифровые портреты EVERA</title>
 <meta name="description" content="Библиотека «Вечных»: открытая коллекция цифровых портретов исторических фигур, меценатов и педагогов. Узнайте о миссии, критериях отбора и способах участия.">
 <link rel="icon" href="/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/pages/eternals.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/pages/eternals.html?lang=en">
+<link rel="alternate" hreflang="ru" href="https://evera.world/eternals">
+<link rel="alternate" hreflang="en" href="https://evera.world/en/eternals">
 <link rel="canonical" href="https://evera.world/eternals">
 <link rel="stylesheet" href="/css/styles.css">
 </head>
@@ -19,9 +19,9 @@
     <a class="logo" href="../index.html#mission" aria-label="EVERA">
       <img src="../evera-logo-white.svg" alt="EVERA logo">
     </a>
-    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню / Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню" aria-expanded="false" aria-controls="navDrawer">☰</button>
     <nav class="links" id="primaryNav" aria-label="Основная навигация">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="menu-group" aria-label="Навигация по разделам страницы">
           <a href="../index.html#mission">Главная</a>
           <a href="../index.html#what">Что такое</a>
@@ -35,24 +35,11 @@
           <a href="../index.html#faq">FAQ</a>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="menu-group" aria-label="Navigate page sections">
-          <a href="../index.html#mission">Home</a>
-          <a href="../index.html#what">What</a>
-          <a href="../index.html#process">Process</a>
-          <a href="../index.html#ai">AI</a>
-          <a href="../index.html#book">Book of Life</a>
-          <a href="../index.html#eternals">Eternals</a>
-          <a href="../index.html#audience">Audience</a>
-          <a href="../index.html#b2b">Business</a>
-          <a href="../index.html#ethics">Ethics</a>
-          <a href="../index.html#faq">FAQ</a>
-        </div>
-      </article>
+      
     </nav>
-    <select class="lang-switch" aria-label="Switch language">
-      <option value="ru">RU</option>
-      <option value="en">EN</option>
+    <select class="lang-switch" aria-label="Переключить язык">
+      <option value="ru" data-url="/pages/eternals.html" selected>RU</option>
+      <option value="en" data-url="/en/pages/eternals.html">EN</option>
     </select>
   </div>
 </header>
@@ -60,14 +47,14 @@
 <aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
   <div class="nav-drawer__header">
     <h2 id="menuTitle">
-      <span data-lang="ru" lang="ru">Меню</span>
-      <span data-lang="en" lang="en" hidden>Menu</span>
+      <span lang="ru">Меню</span>
+      
     </h2>
-    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню / Close menu">✕</button>
+    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню">✕</button>
   </div>
 
   <nav class="nav-drawer__body stack" aria-label="Навигация по сайту">
-    <article data-lang="ru" lang="ru" class="stack">
+    <article lang="ru" class="stack">
       <div class="drawer-group stack">
         <div class="drawer-title">Разделы</div>
         <a href="../index.html#mission">Главная</a>
@@ -84,57 +71,31 @@
 
       <div class="drawer-group stack">
         <div class="drawer-title">Страницы</div>
-        <a href="pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Тарифы</a>
-        <a href="methodology.html" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Методология</a>
-        <a href="book.html" data-href-ru="book.html" data-href-en="book.html?lang=en">Издание «Книга Жизни»</a>
-        <a href="eternals.html" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en" class="active">Библиотека «Вечных»</a>
-        <a href="b2b.html" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">Корпоративные решения</a>
-        <a href="cases.html" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Кейсы</a>
-        <a href="team.html" data-href-ru="team.html" data-href-en="team.html?lang=en">Команда</a>
-        <a href="roadmap.html" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Роадмап</a>
+        <a href="pricing.html">Тарифы</a>
+        <a href="methodology.html">Методология</a>
+        <a href="book.html">Издание «Книга Жизни»</a>
+        <a href="eternals.html" class="active">Библиотека «Вечных»</a>
+        <a href="b2b.html">Корпоративные решения</a>
+        <a href="cases.html">Кейсы</a>
+        <a href="team.html">Команда</a>
+        <a href="roadmap.html">Роадмап</a>
       </div>
     </article>
 
-    <article data-lang="en" lang="en" class="stack" hidden>
-      <div class="drawer-group stack">
-        <div class="drawer-title">Sections</div>
-        <a href="../index.html#mission">Home</a>
-        <a href="../index.html#what">What</a>
-        <a href="../index.html#process">Process</a>
-        <a href="../index.html#ai">AI</a>
-        <a href="../index.html#book">Book of Life</a>
-        <a href="../index.html#eternals">Eternals</a>
-        <a href="../index.html#audience">Audience</a>
-        <a href="../index.html#b2b">Business</a>
-        <a href="../index.html#ethics">Ethics</a>
-        <a href="../index.html#faq">FAQ</a>
-      </div>
-
-      <div class="drawer-group stack">
-        <div class="drawer-title">Pages</div>
-        <a href="../en/pages/pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Pricing</a>
-        <a href="methodology.html?lang=en" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Methodology</a>
-        <a href="book.html?lang=en" data-href-ru="book.html" data-href-en="book.html?lang=en">Book of Life</a>
-        <a href="eternals.html?lang=en" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en" class="active">Eternals Library</a>
-        <a href="b2b.html?lang=en" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">B2B solutions</a>
-        <a href="cases.html?lang=en" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Cases</a>
-        <a href="team.html?lang=en" data-href-ru="team.html" data-href-en="team.html?lang=en">Team</a>
-        <a href="roadmap.html?lang=en" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Roadmap</a>
-      </div>
-    </article>
+    
   </nav>
   <div class="nav-drawer__footer">
     <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
       <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
     </a>
     <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
-      <span data-lang="ru" lang="ru">Telegram-канал</span>
-      <span data-lang="en" lang="en" hidden>Telegram channel</span>
+      <span lang="ru">Telegram-канал</span>
+      
     </a>
   </div>
 </aside>
 <main>
-  <article class="page-intro" data-lang="ru" lang="ru">
+  <article class="page-intro" lang="ru">
     <section class="section">
       <div class="container">
         <h1>Библиотека «Вечных»</h1>
@@ -224,96 +185,7 @@
       </div>
     </section>
   </article>
-  <article class="page-intro" data-lang="en" lang="en" hidden>
-    <section class="section">
-      <div class="container">
-        <h1>Eternals Library</h1>
-        <p class="lead">A public collection of digital portraits of people whose ideas shape culture, education, and civic life. It is a space for intergenerational dialogue.</p>
-        <div class="pill-list"><span>Education</span><span>Culture</span><span>Civic society</span></div>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Mission</div>
-        <h2>Why the library exists</h2>
-        <div class="two-column">
-          <div>
-            <p>We preserve the voices of teachers, researchers, philanthropists, and civic leaders. Their digital portraits are available to schools, museums, and community projects.</p>
-            <p class="quote">“The Eternals” invite honest conversations about values, mistakes, and choices. Every answer shows its source.</p>
-          </div>
-          <div>
-            <h3>Programs</h3>
-            <ul>
-              <li>Educational lessons and history workshops.</li>
-              <li>Museum exhibitions and audio guides.</li>
-              <li>Civic initiatives and urban research.</li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Criteria</div>
-        <h2>Who we feature</h2>
-        <div class="cards-grid">
-          <div class="card">
-            <h3>Documented legacy</h3>
-            <p>Proven achievements and measurable impact on professional or civic communities.</p>
-          </div>
-          <div class="card">
-            <h3>Ethical consent</h3>
-            <p>Permissions from family, foundations, or rights holders, plus clear usage limitations.</p>
-          </div>
-          <div class="card">
-            <h3>Accessible sources</h3>
-            <p>Interviews, letters, photos, and archives ready for analysis and publication.</p>
-          </div>
-          <div class="card">
-            <h3>Educational value</h3>
-            <p>Helps explain values, skills, or historical context through dialogue.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Participation</div>
-        <h2>How to add a portrait</h2>
-        <ul class="timeline">
-          <li><strong>Application.</strong> Send a profile summary, available materials, and your goals.</li>
-          <li><strong>Expert session.</strong> Together we define the format and verify legal status of the sources.</li>
-          <li><strong>Portrait creation.</strong> Interviews, analytics, Book of Life, and dialogue module.</li>
-          <li><strong>Publication.</strong> Launch in the library with learning materials and access policies.</li>
-          <li><strong>Curatorship.</strong> Ongoing updates, feedback collection, and new educational scenarios.</li>
-        </ul>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Partners</div>
-        <h2>Who can use the library</h2>
-        <div class="table-like">
-          <div class="row">
-            <h3>Schools &amp; universities</h3>
-            <p>Access to themed portraits, lesson plans, and licensing for teachers.</p>
-          </div>
-          <div class="row">
-            <h3>Museums &amp; cultural centres</h3>
-            <p>Digital exhibitions, audio guides, and AR markers for showcases.</p>
-          </div>
-          <div class="row">
-            <h3>Foundations &amp; NGOs</h3>
-            <p>Tools for memorial projects, city tours, and documentary programs.</p>
-          </div>
-        </div>
-        <div class="cta-block">
-          <p>Do you know a person who should become part of the Eternals Library? Write to us and receive guidelines on preparing the materials.</p>
-          <a class="btn" href="mailto:eternals@evera.world">Propose a portrait</a>
-        </div>
-      </div>
-    </section>
-  </article>
+  
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/js/app.js"></script>

--- a/pages/methodology.html
+++ b/pages/methodology.html
@@ -5,8 +5,8 @@
 <title>Методология EVERA | цифровая биография и диалог</title>
 <meta name="description" content="Методология EVERA: интервью 150+ вопросов, аналитика голоса и эмоций, редакторская валидация и диалоговый ИИ. Узнайте, как создаётся цифровая биография на русском и английском языках.">
 <link rel="icon" href="/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/pages/methodology.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/pages/methodology.html?lang=en">
+<link rel="alternate" hreflang="ru" href="https://evera.world/methodology">
+<link rel="alternate" hreflang="en" href="https://evera.world/en/methodology">
 <link rel="canonical" href="https://evera.world/methodology">
 <link rel="stylesheet" href="/css/styles.css">
 </head>
@@ -19,9 +19,9 @@
     <a class="logo" href="../index.html#mission" aria-label="EVERA">
       <img src="../evera-logo-white.svg" alt="EVERA logo">
     </a>
-    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню / Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню" aria-expanded="false" aria-controls="navDrawer">☰</button>
     <nav class="links" id="primaryNav" aria-label="Основная навигация">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="menu-group" aria-label="Навигация по разделам страницы">
           <a href="../index.html#mission">Главная</a>
           <a href="../index.html#what">Что такое</a>
@@ -35,24 +35,11 @@
           <a href="../index.html#faq">FAQ</a>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="menu-group" aria-label="Navigate page sections">
-          <a href="../index.html#mission">Home</a>
-          <a href="../index.html#what">What</a>
-          <a href="../index.html#process">Process</a>
-          <a href="../index.html#ai">AI</a>
-          <a href="../index.html#book">Book of Life</a>
-          <a href="../index.html#eternals">Eternals</a>
-          <a href="../index.html#audience">Audience</a>
-          <a href="../index.html#b2b">Business</a>
-          <a href="../index.html#ethics">Ethics</a>
-          <a href="../index.html#faq">FAQ</a>
-        </div>
-      </article>
+      
     </nav>
-    <select class="lang-switch" aria-label="Switch language">
-      <option value="ru">RU</option>
-      <option value="en">EN</option>
+    <select class="lang-switch" aria-label="Переключить язык">
+      <option value="ru" data-url="/pages/methodology.html" selected>RU</option>
+      <option value="en" data-url="/en/pages/methodology.html">EN</option>
     </select>
   </div>
 </header>
@@ -60,14 +47,14 @@
 <aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
   <div class="nav-drawer__header">
     <h2 id="menuTitle">
-      <span data-lang="ru" lang="ru">Меню</span>
-      <span data-lang="en" lang="en" hidden>Menu</span>
+      <span lang="ru">Меню</span>
+      
     </h2>
-    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню / Close menu">✕</button>
+    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню">✕</button>
   </div>
 
   <nav class="nav-drawer__body stack" aria-label="Навигация по сайту">
-    <article data-lang="ru" lang="ru" class="stack">
+    <article lang="ru" class="stack">
       <div class="drawer-group stack">
         <div class="drawer-title">Разделы</div>
         <a href="../index.html#mission">Главная</a>
@@ -84,57 +71,31 @@
 
       <div class="drawer-group stack">
         <div class="drawer-title">Страницы</div>
-        <a href="pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Тарифы</a>
-        <a href="methodology.html" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en" class="active">Методология</a>
-        <a href="book.html" data-href-ru="book.html" data-href-en="book.html?lang=en">Издание «Книга Жизни»</a>
-        <a href="eternals.html" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Библиотека «Вечных»</a>
-        <a href="b2b.html" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">Корпоративные решения</a>
-        <a href="cases.html" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Кейсы</a>
-        <a href="team.html" data-href-ru="team.html" data-href-en="team.html?lang=en">Команда</a>
-        <a href="roadmap.html" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Роадмап</a>
+        <a href="pricing.html">Тарифы</a>
+        <a href="methodology.html" class="active">Методология</a>
+        <a href="book.html">Издание «Книга Жизни»</a>
+        <a href="eternals.html">Библиотека «Вечных»</a>
+        <a href="b2b.html">Корпоративные решения</a>
+        <a href="cases.html">Кейсы</a>
+        <a href="team.html">Команда</a>
+        <a href="roadmap.html">Роадмап</a>
       </div>
     </article>
 
-    <article data-lang="en" lang="en" class="stack" hidden>
-      <div class="drawer-group stack">
-        <div class="drawer-title">Sections</div>
-        <a href="../index.html#mission">Home</a>
-        <a href="../index.html#what">What</a>
-        <a href="../index.html#process">Process</a>
-        <a href="../index.html#ai">AI</a>
-        <a href="../index.html#book">Book of Life</a>
-        <a href="../index.html#eternals">Eternals</a>
-        <a href="../index.html#audience">Audience</a>
-        <a href="../index.html#b2b">Business</a>
-        <a href="../index.html#ethics">Ethics</a>
-        <a href="../index.html#faq">FAQ</a>
-      </div>
-
-      <div class="drawer-group stack">
-        <div class="drawer-title">Pages</div>
-        <a href="../en/pages/pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Pricing</a>
-        <a href="methodology.html?lang=en" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en" class="active">Methodology</a>
-        <a href="book.html?lang=en" data-href-ru="book.html" data-href-en="book.html?lang=en">Book of Life</a>
-        <a href="eternals.html?lang=en" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Eternals Library</a>
-        <a href="b2b.html?lang=en" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">B2B solutions</a>
-        <a href="cases.html?lang=en" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Cases</a>
-        <a href="team.html?lang=en" data-href-ru="team.html" data-href-en="team.html?lang=en">Team</a>
-        <a href="roadmap.html?lang=en" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Roadmap</a>
-      </div>
-    </article>
+    
   </nav>
   <div class="nav-drawer__footer">
     <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
       <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
     </a>
     <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
-      <span data-lang="ru" lang="ru">Telegram-канал</span>
-      <span data-lang="en" lang="en" hidden>Telegram channel</span>
+      <span lang="ru">Telegram-канал</span>
+      
     </a>
   </div>
 </aside>
 <main>
-  <article class="page-intro" data-lang="ru" lang="ru">
+  <article class="page-intro" lang="ru">
     <section class="section">
       <div class="container">
         <h1>Методология EVERA</h1>
@@ -227,99 +188,7 @@
       </div>
     </section>
   </article>
-  <article class="page-intro" data-lang="en" lang="en" hidden>
-    <section class="section">
-      <div class="container">
-        <h1>EVERA Methodology</h1>
-        <p class="lead">A certified framework that combines 150+ guided interview questions, cognitive speech analytics, and human editorial review. The result is a digital biography that sounds like the person you remember.</p>
-        <div class="pill-list">
-          <span>150+ questions</span><span>Audio &amp; video</span><span>Ethical review</span><span>Dialogue AI</span>
-        </div>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Principles</div>
-        <h2>What keeps an EVERA portrait authentic</h2>
-        <ul>
-          <li><strong>Voice and memory guide the process.</strong> Technology helps structure the material, yet the family and the narrator approve every step.</li>
-          <li><strong>Verified sources only.</strong> Every fact is checked with documents, witnesses, or archives before entering the final corpus.</li>
-          <li><strong>Transparency and control.</strong> Participants can pause the production or close specific storylines without losing progress.</li>
-          <li><strong>Ethics and consent.</strong> We comply with GDPR, local data regulations, and our internal code of memorial respect.</li>
-        </ul>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Process</div>
-        <h2>From first interview to living dialogue</h2>
-        <div class="cards-grid">
-          <div class="card">
-            <h3>Preparation</h3>
-            <p>Onboarding for the family, artefact collection, and roadmap design. A curator helps define priorities, sensitive topics, and narrative limits.</p>
-            <p><strong>Outcome:</strong> approved interview script and data checklist.</p>
-          </div>
-          <div class="card">
-            <h3>Interviews</h3>
-            <p>Three to six sessions, 60–90 minutes each, online or in person. We adapt the questions, trace emotions, and tag people, places, and turning points.</p>
-            <p><strong>Outcome:</strong> transcripts, timestamps, audio and video files.</p>
-          </div>
-          <div class="card">
-            <h3>Analytics</h3>
-            <p>Linguists and analysts build the memory map: storylines, characters, values, emotional markers. AI extracts vocabulary, tone, and conversational tempo.</p>
-            <p><strong>Outcome:</strong> narrative structure and the base dialogue model.</p>
-          </div>
-          <div class="card">
-            <h3>Editorial &amp; Design</h3>
-            <p>The editorial team assembles the Book of Life chapters, creates the quote library, and designs visual inserts. Legal and tonal checks ensure clear attribution.</p>
-            <p><strong>Outcome:</strong> ready-to-print book layout, dialogue scripts, and artefacts for the Eternals Library.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Validation</div>
-        <h2>Quality assurance workflow</h2>
-        <div class="two-column">
-          <div>
-            <h3>Editorial track</h3>
-            <p>Every interview is reviewed twice. We highlight emotional peaks, clarify chronology, and capture quotations for future search layers.</p>
-            <p>Verification calls with relatives and subject-matter experts (historians, educators, archivists) confirm sensitive facts.</p>
-          </div>
-          <div>
-            <h3>Technical track</h3>
-            <p>The AI module analyses semantic clusters, cross-references answers with documents, and flags possible contradictions.</p>
-            <p>A change log records who edited each fragment to preserve transparency and prevent distortions.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Delivery</div>
-        <h2>How we hand over the portrait</h2>
-        <div class="table-like">
-          <div class="row">
-            <h3>Book of Life</h3>
-            <p>Printed or digital edition with themed chapters, QR codes to audio, and family constellation maps.</p>
-          </div>
-          <div class="row">
-            <h3>Dialogue AI</h3>
-            <p>Role-based access in a private portal. Every answer cites the source interview or artefact.</p>
-          </div>
-          <div class="row">
-            <h3>Eternals Library</h3>
-            <p>Public-ready format for cultural and educational institutions with ethical usage guidelines.</p>
-          </div>
-        </div>
-        <div class="cta-block">
-          <p>Wondering whether the EVERA methodology fits your family or project? Share your context and we will draft a tailored research plan.</p>
-          <a class="btn" href="mailto:hello@evera.world">Talk to a curator</a>
-        </div>
-      </div>
-    </section>
-  </article>
+  
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/js/app.js"></script>

--- a/pages/pricing.html
+++ b/pages/pricing.html
@@ -5,8 +5,8 @@
 <title>Тарифы EVERA | цифровое наследие под ключ</title>
 <meta name="description" content="Тарифы EVERA: Base, Pro и Legacy. Интервью, аналитика, диалоговый ИИ и сопровождение для семей и брендов.">
 <link rel="icon" href="/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/pages/pricing.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/en/pages/pricing.html">
+<link rel="alternate" hreflang="ru" href="https://evera.world/pricing">
+<link rel="alternate" hreflang="en" href="https://evera.world/en/pricing">
 <link rel="canonical" href="https://evera.world/pricing">
 <link rel="stylesheet" href="/css/styles.css">
 </head>
@@ -19,9 +19,9 @@
     <a class="logo" href="../index.html#mission" aria-label="EVERA">
       <img src="../evera-logo-white.svg" alt="EVERA logo">
     </a>
-    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню / Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню" aria-expanded="false" aria-controls="navDrawer">☰</button>
     <nav class="links" id="primaryNav" aria-label="Основная навигация">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="menu-group" aria-label="Навигация по разделам страницы">
           <a href="../index.html#mission">Главная</a>
           <a href="../index.html#what">Что такое</a>
@@ -35,24 +35,11 @@
           <a href="../index.html#faq">FAQ</a>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="menu-group" aria-label="Navigate page sections">
-          <a href="../index.html#mission">Home</a>
-          <a href="../index.html#what">What</a>
-          <a href="../index.html#process">Process</a>
-          <a href="../index.html#ai">AI</a>
-          <a href="../index.html#book">Book of Life</a>
-          <a href="../index.html#eternals">Eternals</a>
-          <a href="../index.html#audience">Audience</a>
-          <a href="../index.html#b2b">Business</a>
-          <a href="../index.html#ethics">Ethics</a>
-          <a href="../index.html#faq">FAQ</a>
-        </div>
-      </article>
+      
     </nav>
-    <select class="lang-switch" aria-label="Switch language">
-      <option value="ru">RU</option>
-      <option value="en">EN</option>
+    <select class="lang-switch" aria-label="Переключить язык">
+      <option value="ru" data-url="/pages/pricing.html" selected>RU</option>
+      <option value="en" data-url="/en/pages/pricing.html">EN</option>
     </select>
   </div>
 </header>
@@ -60,14 +47,14 @@
 <aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
   <div class="nav-drawer__header">
     <h2 id="menuTitle">
-      <span data-lang="ru" lang="ru">Меню</span>
-      <span data-lang="en" lang="en" hidden>Menu</span>
+      <span lang="ru">Меню</span>
+      
     </h2>
-    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню / Close menu">✕</button>
+    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню">✕</button>
   </div>
 
   <nav class="nav-drawer__body stack" aria-label="Навигация по сайту">
-    <article data-lang="ru" lang="ru" class="stack">
+    <article lang="ru" class="stack">
       <div class="drawer-group stack">
         <div class="drawer-title">Разделы</div>
         <a href="../index.html#mission">Главная</a>
@@ -84,57 +71,31 @@
 
       <div class="drawer-group stack">
         <div class="drawer-title">Страницы</div>
-        <a href="pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html" class="active">Тарифы</a>
-        <a href="methodology.html" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Методология</a>
-        <a href="book.html" data-href-ru="book.html" data-href-en="book.html?lang=en">Издание «Книга Жизни»</a>
-        <a href="eternals.html" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Библиотека «Вечных»</a>
-        <a href="b2b.html" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">Корпоративные решения</a>
-        <a href="cases.html" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Кейсы</a>
-        <a href="team.html" data-href-ru="team.html" data-href-en="team.html?lang=en">Команда</a>
-        <a href="roadmap.html" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Роадмап</a>
+        <a href="pricing.html" class="active">Тарифы</a>
+        <a href="methodology.html">Методология</a>
+        <a href="book.html">Издание «Книга Жизни»</a>
+        <a href="eternals.html">Библиотека «Вечных»</a>
+        <a href="b2b.html">Корпоративные решения</a>
+        <a href="cases.html">Кейсы</a>
+        <a href="team.html">Команда</a>
+        <a href="roadmap.html">Роадмап</a>
       </div>
     </article>
 
-    <article data-lang="en" lang="en" class="stack" hidden>
-      <div class="drawer-group stack">
-        <div class="drawer-title">Sections</div>
-        <a href="../index.html#mission">Home</a>
-        <a href="../index.html#what">What</a>
-        <a href="../index.html#process">Process</a>
-        <a href="../index.html#ai">AI</a>
-        <a href="../index.html#book">Book of Life</a>
-        <a href="../index.html#eternals">Eternals</a>
-        <a href="../index.html#audience">Audience</a>
-        <a href="../index.html#b2b">Business</a>
-        <a href="../index.html#ethics">Ethics</a>
-        <a href="../index.html#faq">FAQ</a>
-      </div>
-
-      <div class="drawer-group stack">
-        <div class="drawer-title">Pages</div>
-        <a href="../en/pages/pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html" class="active">Pricing</a>
-        <a href="methodology.html?lang=en" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Methodology</a>
-        <a href="book.html?lang=en" data-href-ru="book.html" data-href-en="book.html?lang=en">Book of Life</a>
-        <a href="eternals.html?lang=en" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Eternals Library</a>
-        <a href="b2b.html?lang=en" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">B2B solutions</a>
-        <a href="cases.html?lang=en" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Cases</a>
-        <a href="team.html?lang=en" data-href-ru="team.html" data-href-en="team.html?lang=en">Team</a>
-        <a href="roadmap.html?lang=en" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Roadmap</a>
-      </div>
-    </article>
+    
   </nav>
   <div class="nav-drawer__footer">
     <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
       <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
     </a>
     <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
-      <span data-lang="ru" lang="ru">Telegram-канал</span>
-      <span data-lang="en" lang="en" hidden>Telegram channel</span>
+      <span lang="ru">Telegram-канал</span>
+      
     </a>
   </div>
 </aside>
 <main>
-  <article class="page-intro" data-lang="ru" lang="ru">
+  <article class="page-intro" lang="ru">
     <section class="section">
       <div class="container">
         <h1>Тарифы EVERA</h1>
@@ -218,90 +179,7 @@
       </div>
     </section>
   </article>
-  <article class="page-intro" data-lang="en" lang="en" hidden>
-    <section class="section">
-      <div class="container">
-        <h1>EVERA Pricing</h1>
-        <p class="lead">Choose the format that fits your story: from a family Book of Life to a corporate knowledge base with conversational AI. Every tier bundles interviews, analytics, and guided launch.</p>
-        <div class="pill-list"><span>150+ prompts</span><span>AI archive</span><span>Dialogue access</span><span>Editorial team</span></div>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Plans</div>
-        <h2>Select your configuration</h2>
-        <div class="pricing-grid">
-          <div class="tariff-card">
-            <span class="tag">Base</span>
-            <div class="price">120,000&nbsp;₽</div>
-            <p class="meta">6 weeks, one protagonist, digital Book of Life delivery.</p>
-            <ul>
-              <li>Up to three interviews (remote/on-site) covering 150+ prompts.</li>
-              <li>Speech, emotion, and theme analytics with curator notes.</li>
-              <li>Digital Book of Life (PDF) with timeline, quotes, and media.</li>
-              <li>Foundational dialogue model with private family access.</li>
-            </ul>
-            <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20Base%20-%20Request%20a%20quote">Request a quote</a>
-          </div>
-          <div class="tariff-card is-popular">
-            <span class="tag">Pro</span>
-            <div class="price">280,000&nbsp;₽</div>
-            <p class="meta">3 months, up to three protagonists, extended AI dialogue and family archive.</p>
-            <ul>
-              <li>Up to six interviews plus bonus sessions with relatives or partners.</li>
-              <li>Advanced analytics: timelines, genealogy, semantic mapping.</li>
-              <li>Dialogue AI with themed modes and citation links to sources.</li>
-              <li>Family portal with access management and onboarding workshop.</li>
-            </ul>
-            <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20Pro%20-%20Request%20a%20quote">Request a quote</a>
-          </div>
-          <div class="tariff-card">
-            <span class="tag">Legacy</span>
-            <div class="price">520,000&nbsp;₽</div>
-            <p class="meta">6 months, 3+ protagonists, printed edition and long-term portrait stewardship.</p>
-            <ul>
-              <li>Full editorial expedition with on-site recording and archive digitisation.</li>
-              <li>Printed Book of Life plus interactive edition with QR-linked media.</li>
-              <li>Private dialogue AI with moderator oversight and rolling updates.</li>
-              <li>12 months of curation with options for corporate or museum scenarios.</li>
-            </ul>
-            <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20Legacy%20-%20Request%20a%20quote">Request a quote</a>
-          </div>
-        </div>
-        <div class="cta-block">
-          <p>Have a special project in mind - a memorial museum, bilingual archive, or enterprise deployment? We will scope a custom offer and assign a curator within two business days.</p>
-          <div class="cta-actions">
-            <a class="btn" href="mailto:hello@evera.world?subject=EVERA%20-%20Request%20a%20quote">Request a quote</a>
-            <a class="btn ghost" href="https://t.me/Solo013" target="_blank" rel="noopener">Chat on Telegram</a>
-          </div>
-        </div>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Included</div>
-        <h2>Every plan covers</h2>
-        <div class="cards-grid">
-          <div class="card">
-            <h3>Interviews & materials</h3>
-            <p>We design the script, conduct interviews, and digitise letters, photos, and videos.</p>
-          </div>
-          <div class="card">
-            <h3>Analysis & editing</h3>
-            <p>We extract narratives, emotions, and lexicon to craft the Book of Life and knowledge base.</p>
-          </div>
-          <div class="card">
-            <h3>Dialogue AI</h3>
-            <p>We configure a conversational portrait with trustworthy citations and flexible access.</p>
-          </div>
-          <div class="card">
-            <h3>Support</h3>
-            <p>We train the family or team, refresh the model, and help integrate it into daily scenarios.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-  </article>
+  
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/js/app.js"></script>

--- a/pages/roadmap.html
+++ b/pages/roadmap.html
@@ -5,8 +5,8 @@
 <title>Дорожная карта EVERA | развитие продукта и исследований</title>
 <meta name="description" content="Планы развития EVERA: новые релизы, исследовательские треки, международные партнёрства. Ознакомьтесь с дорожной картой на русском и английском языках.">
 <link rel="icon" href="/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/pages/roadmap.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/pages/roadmap.html?lang=en">
+<link rel="alternate" hreflang="ru" href="https://evera.world/roadmap">
+<link rel="alternate" hreflang="en" href="https://evera.world/en/roadmap">
 <link rel="canonical" href="https://evera.world/roadmap">
 <link rel="stylesheet" href="/css/styles.css">
 </head>
@@ -19,9 +19,9 @@
     <a class="logo" href="../index.html#mission" aria-label="EVERA">
       <img src="../evera-logo-white.svg" alt="EVERA logo">
     </a>
-    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню / Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню" aria-expanded="false" aria-controls="navDrawer">☰</button>
     <nav class="links" id="primaryNav" aria-label="Основная навигация">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="menu-group" aria-label="Навигация по разделам страницы">
           <a href="../index.html#mission">Главная</a>
           <a href="../index.html#what">Что такое</a>
@@ -35,24 +35,11 @@
           <a href="../index.html#faq">FAQ</a>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="menu-group" aria-label="Navigate page sections">
-          <a href="../index.html#mission">Home</a>
-          <a href="../index.html#what">What</a>
-          <a href="../index.html#process">Process</a>
-          <a href="../index.html#ai">AI</a>
-          <a href="../index.html#book">Book of Life</a>
-          <a href="../index.html#eternals">Eternals</a>
-          <a href="../index.html#audience">Audience</a>
-          <a href="../index.html#b2b">Business</a>
-          <a href="../index.html#ethics">Ethics</a>
-          <a href="../index.html#faq">FAQ</a>
-        </div>
-      </article>
+      
     </nav>
-    <select class="lang-switch" aria-label="Switch language">
-      <option value="ru">RU</option>
-      <option value="en">EN</option>
+    <select class="lang-switch" aria-label="Переключить язык">
+      <option value="ru" data-url="/pages/roadmap.html" selected>RU</option>
+      <option value="en" data-url="/en/pages/roadmap.html">EN</option>
     </select>
   </div>
 </header>
@@ -60,14 +47,14 @@
 <aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
   <div class="nav-drawer__header">
     <h2 id="menuTitle">
-      <span data-lang="ru" lang="ru">Меню</span>
-      <span data-lang="en" lang="en" hidden>Menu</span>
+      <span lang="ru">Меню</span>
+      
     </h2>
-    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню / Close menu">✕</button>
+    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню">✕</button>
   </div>
 
   <nav class="nav-drawer__body stack" aria-label="Навигация по сайту">
-    <article data-lang="ru" lang="ru" class="stack">
+    <article lang="ru" class="stack">
       <div class="drawer-group stack">
         <div class="drawer-title">Разделы</div>
         <a href="../index.html#mission">Главная</a>
@@ -84,57 +71,31 @@
 
       <div class="drawer-group stack">
         <div class="drawer-title">Страницы</div>
-        <a href="pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Тарифы</a>
-        <a href="methodology.html" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Методология</a>
-        <a href="book.html" data-href-ru="book.html" data-href-en="book.html?lang=en">Издание «Книга Жизни»</a>
-        <a href="eternals.html" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Библиотека «Вечных»</a>
-        <a href="b2b.html" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">Корпоративные решения</a>
-        <a href="cases.html" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Кейсы</a>
-        <a href="team.html" data-href-ru="team.html" data-href-en="team.html?lang=en">Команда</a>
-        <a href="roadmap.html" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en" class="active">Роадмап</a>
+        <a href="pricing.html">Тарифы</a>
+        <a href="methodology.html">Методология</a>
+        <a href="book.html">Издание «Книга Жизни»</a>
+        <a href="eternals.html">Библиотека «Вечных»</a>
+        <a href="b2b.html">Корпоративные решения</a>
+        <a href="cases.html">Кейсы</a>
+        <a href="team.html">Команда</a>
+        <a href="roadmap.html" class="active">Роадмап</a>
       </div>
     </article>
 
-    <article data-lang="en" lang="en" class="stack" hidden>
-      <div class="drawer-group stack">
-        <div class="drawer-title">Sections</div>
-        <a href="../index.html#mission">Home</a>
-        <a href="../index.html#what">What</a>
-        <a href="../index.html#process">Process</a>
-        <a href="../index.html#ai">AI</a>
-        <a href="../index.html#book">Book of Life</a>
-        <a href="../index.html#eternals">Eternals</a>
-        <a href="../index.html#audience">Audience</a>
-        <a href="../index.html#b2b">Business</a>
-        <a href="../index.html#ethics">Ethics</a>
-        <a href="../index.html#faq">FAQ</a>
-      </div>
-
-      <div class="drawer-group stack">
-        <div class="drawer-title">Pages</div>
-        <a href="../en/pages/pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Pricing</a>
-        <a href="methodology.html?lang=en" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Methodology</a>
-        <a href="book.html?lang=en" data-href-ru="book.html" data-href-en="book.html?lang=en">Book of Life</a>
-        <a href="eternals.html?lang=en" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Eternals Library</a>
-        <a href="b2b.html?lang=en" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">B2B solutions</a>
-        <a href="cases.html?lang=en" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Cases</a>
-        <a href="team.html?lang=en" data-href-ru="team.html" data-href-en="team.html?lang=en">Team</a>
-        <a href="roadmap.html?lang=en" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en" class="active">Roadmap</a>
-      </div>
-    </article>
+    
   </nav>
   <div class="nav-drawer__footer">
     <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
       <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
     </a>
     <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
-      <span data-lang="ru" lang="ru">Telegram-канал</span>
-      <span data-lang="en" lang="en" hidden>Telegram channel</span>
+      <span lang="ru">Telegram-канал</span>
+      
     </a>
   </div>
 </aside>
 <main>
-  <article class="page-intro" data-lang="ru" lang="ru">
+  <article class="page-intro" lang="ru">
     <section class="section">
       <div class="container">
         <h1>Дорожная карта EVERA</h1>
@@ -191,63 +152,7 @@
       </div>
     </section>
   </article>
-  <article class="page-intro" data-lang="en" lang="en" hidden>
-    <section class="section">
-      <div class="container">
-        <h1>EVERA Roadmap</h1>
-        <p class="lead">We are building a product that unites digital biographies, dialogue AI, and ethical memorial practices. Here are the milestones planned for 2024–2026.</p>
-        <div class="pill-list"><span>2024</span><span>2025</span><span>2026</span></div>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Product</div>
-        <h2>Upcoming releases</h2>
-        <ul class="timeline">
-          <li><strong>Q2 2024: Book of Life 2.0.</strong> New layout editor, dynamic QR modules, and an expanded emotion glossary.</li>
-          <li><strong>Q3 2024: Private family portal.</strong> Role-based permissions, edit logs, and secure artefact sharing.</li>
-          <li><strong>Q1 2025: Voice-enabled dialogue AI.</strong> Expressive speech synthesis based on approved samples with transparent citations.</li>
-          <li><strong>Q3 2025: Public portraits.</strong> First collections released in the Eternals Library with ready-to-use lesson plans.</li>
-          <li><strong>2026: Global launch.</strong> Multilingual support, partnerships with archives, and an API for research centres.</li>
-        </ul>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Research</div>
-        <h2>Exploration tracks</h2>
-        <div class="cards-grid">
-          <div class="card">
-            <h3>Ethics &amp; legal frameworks</h3>
-            <p>We design a code of conduct for digital twins and template agreements for families, museums, and companies.</p>
-          </div>
-          <div class="card">
-            <h3>Narrative analytics</h3>
-            <p>Studying how emotions and vocabulary reflect personal values and teaching the AI to cite sources correctly.</p>
-          </div>
-          <div class="card">
-            <h3>Multiformat archives</h3>
-            <p>Building a pipeline that preserves audio, video, letters, and artefacts so the portrait stays relevant for decades.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Impact</div>
-        <h2>Success indicators</h2>
-        <div class="stat-grid">
-          <div class="stat"><b>500+</b>families and institutions in the ecosystem</div>
-          <div class="stat"><b>80%</b>portraits refreshed every year</div>
-          <div class="stat"><b>15</b>international partner institutions</div>
-        </div>
-        <div class="cta-block">
-          <p>Interested in pilots or research collaborations? Write to us and we will discuss access to early releases.</p>
-          <a class="btn" href="mailto:roadmap@evera.world">Join the pilot</a>
-        </div>
-      </div>
-    </section>
-  </article>
+  
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/js/app.js"></script>

--- a/pages/team.html
+++ b/pages/team.html
@@ -5,8 +5,8 @@
 <title>Команда EVERA | кураторы памяти, редакторы, инженеры</title>
 <meta name="description" content="Познакомьтесь с командой EVERA: кураторы памяти, редакторы, инженеры ИИ и экспертный совет. Узнайте, как мы бережно создаём цифровые портреты и Книги Жизни.">
 <link rel="icon" href="/assets/icons/favicon.svg">
-<link rel="alternate" hreflang="ru" href="/pages/team.html?lang=ru">
-<link rel="alternate" hreflang="en" href="/pages/team.html?lang=en">
+<link rel="alternate" hreflang="ru" href="https://evera.world/team">
+<link rel="alternate" hreflang="en" href="https://evera.world/en/team">
 <link rel="canonical" href="https://evera.world/team">
 <link rel="stylesheet" href="/css/styles.css">
 </head>
@@ -19,9 +19,9 @@
     <a class="logo" href="../index.html#mission" aria-label="EVERA">
       <img src="../evera-logo-white.svg" alt="EVERA logo">
     </a>
-    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню / Menu" aria-expanded="false" aria-controls="navDrawer">☰</button>
+    <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню" aria-expanded="false" aria-controls="navDrawer">☰</button>
     <nav class="links" id="primaryNav" aria-label="Основная навигация">
-      <article data-lang="ru" lang="ru">
+      <article lang="ru">
         <div class="menu-group" aria-label="Навигация по разделам страницы">
           <a href="../index.html#mission">Главная</a>
           <a href="../index.html#what">Что такое</a>
@@ -35,24 +35,11 @@
           <a href="../index.html#faq">FAQ</a>
         </div>
       </article>
-      <article data-lang="en" lang="en" hidden>
-        <div class="menu-group" aria-label="Navigate page sections">
-          <a href="../index.html#mission">Home</a>
-          <a href="../index.html#what">What</a>
-          <a href="../index.html#process">Process</a>
-          <a href="../index.html#ai">AI</a>
-          <a href="../index.html#book">Book of Life</a>
-          <a href="../index.html#eternals">Eternals</a>
-          <a href="../index.html#audience">Audience</a>
-          <a href="../index.html#b2b">Business</a>
-          <a href="../index.html#ethics">Ethics</a>
-          <a href="../index.html#faq">FAQ</a>
-        </div>
-      </article>
+      
     </nav>
-    <select class="lang-switch" aria-label="Switch language">
-      <option value="ru">RU</option>
-      <option value="en">EN</option>
+    <select class="lang-switch" aria-label="Переключить язык">
+      <option value="ru" data-url="/pages/team.html" selected>RU</option>
+      <option value="en" data-url="/en/pages/team.html">EN</option>
     </select>
   </div>
 </header>
@@ -60,14 +47,14 @@
 <aside class="nav-drawer" id="navDrawer" aria-hidden="true" aria-labelledby="menuTitle" role="dialog" aria-modal="true">
   <div class="nav-drawer__header">
     <h2 id="menuTitle">
-      <span data-lang="ru" lang="ru">Меню</span>
-      <span data-lang="en" lang="en" hidden>Menu</span>
+      <span lang="ru">Меню</span>
+      
     </h2>
-    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню / Close menu">✕</button>
+    <button class="nav-drawer__close" id="navClose" aria-label="Закрыть меню">✕</button>
   </div>
 
   <nav class="nav-drawer__body stack" aria-label="Навигация по сайту">
-    <article data-lang="ru" lang="ru" class="stack">
+    <article lang="ru" class="stack">
       <div class="drawer-group stack">
         <div class="drawer-title">Разделы</div>
         <a href="../index.html#mission">Главная</a>
@@ -84,57 +71,31 @@
 
       <div class="drawer-group stack">
         <div class="drawer-title">Страницы</div>
-        <a href="pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Тарифы</a>
-        <a href="methodology.html" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Методология</a>
-        <a href="book.html" data-href-ru="book.html" data-href-en="book.html?lang=en">Издание «Книга Жизни»</a>
-        <a href="eternals.html" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Библиотека «Вечных»</a>
-        <a href="b2b.html" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">Корпоративные решения</a>
-        <a href="cases.html" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Кейсы</a>
-        <a href="team.html" data-href-ru="team.html" data-href-en="team.html?lang=en" class="active">Команда</a>
-        <a href="roadmap.html" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Роадмап</a>
+        <a href="pricing.html">Тарифы</a>
+        <a href="methodology.html">Методология</a>
+        <a href="book.html">Издание «Книга Жизни»</a>
+        <a href="eternals.html">Библиотека «Вечных»</a>
+        <a href="b2b.html">Корпоративные решения</a>
+        <a href="cases.html">Кейсы</a>
+        <a href="team.html" class="active">Команда</a>
+        <a href="roadmap.html">Роадмап</a>
       </div>
     </article>
 
-    <article data-lang="en" lang="en" class="stack" hidden>
-      <div class="drawer-group stack">
-        <div class="drawer-title">Sections</div>
-        <a href="../index.html#mission">Home</a>
-        <a href="../index.html#what">What</a>
-        <a href="../index.html#process">Process</a>
-        <a href="../index.html#ai">AI</a>
-        <a href="../index.html#book">Book of Life</a>
-        <a href="../index.html#eternals">Eternals</a>
-        <a href="../index.html#audience">Audience</a>
-        <a href="../index.html#b2b">Business</a>
-        <a href="../index.html#ethics">Ethics</a>
-        <a href="../index.html#faq">FAQ</a>
-      </div>
-
-      <div class="drawer-group stack">
-        <div class="drawer-title">Pages</div>
-        <a href="../en/pages/pricing.html" data-href-ru="pricing.html" data-href-en="../en/pages/pricing.html">Pricing</a>
-        <a href="methodology.html?lang=en" data-href-ru="methodology.html" data-href-en="methodology.html?lang=en">Methodology</a>
-        <a href="book.html?lang=en" data-href-ru="book.html" data-href-en="book.html?lang=en">Book of Life</a>
-        <a href="eternals.html?lang=en" data-href-ru="eternals.html" data-href-en="eternals.html?lang=en">Eternals Library</a>
-        <a href="b2b.html?lang=en" data-href-ru="b2b.html" data-href-en="b2b.html?lang=en">B2B solutions</a>
-        <a href="cases.html?lang=en" data-href-ru="cases.html" data-href-en="cases.html?lang=en">Cases</a>
-        <a href="team.html?lang=en" data-href-ru="team.html" data-href-en="team.html?lang=en" class="active">Team</a>
-        <a href="roadmap.html?lang=en" data-href-ru="roadmap.html" data-href-en="roadmap.html?lang=en">Roadmap</a>
-      </div>
-    </article>
+    
   </nav>
   <div class="nav-drawer__footer">
     <a class="drawer-brand" href="../index.html#mission" aria-label="EVERA">
       <img src="../evera-logo-white.svg" alt="EVERA" width="96" height="24" loading="lazy">
     </a>
     <a class="btn ghost drawer-telegram" href="https://t.me/sololabschannel" target="_blank" rel="noopener">
-      <span data-lang="ru" lang="ru">Telegram-канал</span>
-      <span data-lang="en" lang="en" hidden>Telegram channel</span>
+      <span lang="ru">Telegram-канал</span>
+      
     </a>
   </div>
 </aside>
 <main>
-  <article class="page-intro" data-lang="ru" lang="ru">
+  <article class="page-intro" lang="ru">
     <section class="section">
       <div class="container">
         <h1>Команда EVERA</h1>
@@ -222,94 +183,7 @@
       </div>
     </section>
   </article>
-  <article class="page-intro" data-lang="en" lang="en" hidden>
-    <section class="section">
-      <div class="container">
-        <h1>The EVERA Team</h1>
-        <p class="lead">We are memory curators, editors, engineers, and researchers who transform life stories into digital dialogue. Our mission is to preserve a person’s voice and values with respect for their family and culture.</p>
-        <div class="pill-list"><span>Curatorship</span><span>Editorial</span><span>AI</span><span>Ethics</span></div>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Approach</div>
-        <h2>Team philosophy</h2>
-        <ul>
-          <li>We work in cross-functional cells that unite researchers, linguists, and designers around each portrait.</li>
-          <li>Every client collaborates with a dedicated curator responsible for empathy, timing, and communication.</li>
-          <li>We follow the principle “nothing about a person without their family” by aligning context and tone in every story.</li>
-        </ul>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Core team</div>
-        <h2>Key roles</h2>
-        <div class="profile-grid">
-          <div class="profile-card">
-            <div class="role">Founder &amp; Vision</div>
-            <h3>Anastasia Vyushina</h3>
-            <p>Founder of EVERA and curator of digital memory projects. Leads strategy, ethics, and international partnerships.</p>
-            <p><strong>Focus:</strong> mission, partnerships, public outreach.</p>
-          </div>
-          <div class="profile-card">
-            <div class="role">Research Director</div>
-            <h3>Dmitry Soloukhin</h3>
-            <p>Narrative researcher with a PhD in cultural studies. Oversees interview methodology and analytical frameworks.</p>
-            <p><strong>Focus:</strong> interview scripts, data validation, curator training.</p>
-          </div>
-          <div class="profile-card">
-            <div class="role">Chief Editor</div>
-            <h3>Maria Klimova</h3>
-            <p>Editor and literary producer experienced in biographies of cultural leaders and educational programs.</p>
-            <p><strong>Focus:</strong> Book of Life, style, fact-checking.</p>
-          </div>
-          <div class="profile-card">
-            <div class="role">AI Architect</div>
-            <h3>Ilya Kim</h3>
-            <p>Machine learning engineer with 10 years in NLP and conversational systems. Builds the memory model and citation layer.</p>
-            <p><strong>Focus:</strong> speech analytics, voice models, data security.</p>
-          </div>
-          <div class="profile-card">
-            <div class="role">Design Lead</div>
-            <h3>Alena Morozova</h3>
-            <p>Art director crafting the visual language of the Book of Life and leading the design and illustration team.</p>
-            <p><strong>Focus:</strong> visual patterns, interactive prototypes.</p>
-          </div>
-          <div class="profile-card">
-            <div class="role">Community &amp; Ethics</div>
-            <h3>Oleg Andreev</h3>
-            <p>Ethics specialist and moderator of memorial communities. Maintains the code of conduct and family agreements.</p>
-            <p><strong>Focus:</strong> access policies, learning sessions, family support.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-    <section class="section">
-      <div class="container">
-        <div class="kicker">Advisory board</div>
-        <h2>Expert partners</h2>
-        <div class="table-like">
-          <div class="row">
-            <h3>Historians &amp; archivists</h3>
-            <p>Verify documents, structure timelines, and advise on long-term preservation of artefacts.</p>
-          </div>
-          <div class="row">
-            <h3>Psychologists &amp; facilitators</h3>
-            <p>Guide sensitive interviews, support families, and suggest safe frameworks for discussing difficult memories.</p>
-          </div>
-          <div class="row">
-            <h3>IP lawyers</h3>
-            <p>Review copyright, regulate access to digital assets, and draft licensing agreements.</p>
-          </div>
-        </div>
-        <div class="cta-block">
-          <p>We welcome collaboration with researchers, artists, and scholars. Reach out if you want to join the team or co-create a project.</p>
-          <a class="btn" href="mailto:team@evera.world">Contact us</a>
-        </div>
-      </div>
-    </section>
-  </article>
+  
 </main>
 <footer class="footer"><div class="small">© 2025 EVERA</div></footer>
 <script src="/js/app.js"></script>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,13 +1,94 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://evera.world/</loc></url>
-  <url><loc>https://evera.world/methodology</loc></url>
-  <url><loc>https://evera.world/cases</loc></url>
-  <url><loc>https://evera.world/team</loc></url>
-  <url><loc>https://evera.world/roadmap</loc></url>
-  <url><loc>https://evera.world/book</loc></url>
-  <url><loc>https://evera.world/b2b</loc></url>
-  <url><loc>https://evera.world/eternals</loc></url>
-  <url><loc>https://evera.world/pricing</loc></url>
-  <url><loc>https://evera.world/en/pricing</loc></url>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://evera.world/</loc>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://evera.world/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://evera.world/en/"/>
+  </url>
+  <url>
+    <loc>https://evera.world/en/</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://evera.world/en/"/>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://evera.world/"/>
+  </url>
+  <url>
+    <loc>https://evera.world/methodology</loc>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://evera.world/methodology"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://evera.world/en/methodology"/>
+  </url>
+  <url>
+    <loc>https://evera.world/en/methodology</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://evera.world/en/methodology"/>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://evera.world/methodology"/>
+  </url>
+  <url>
+    <loc>https://evera.world/cases</loc>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://evera.world/cases"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://evera.world/en/cases"/>
+  </url>
+  <url>
+    <loc>https://evera.world/en/cases</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://evera.world/en/cases"/>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://evera.world/cases"/>
+  </url>
+  <url>
+    <loc>https://evera.world/team</loc>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://evera.world/team"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://evera.world/en/team"/>
+  </url>
+  <url>
+    <loc>https://evera.world/en/team</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://evera.world/en/team"/>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://evera.world/team"/>
+  </url>
+  <url>
+    <loc>https://evera.world/roadmap</loc>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://evera.world/roadmap"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://evera.world/en/roadmap"/>
+  </url>
+  <url>
+    <loc>https://evera.world/en/roadmap</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://evera.world/en/roadmap"/>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://evera.world/roadmap"/>
+  </url>
+  <url>
+    <loc>https://evera.world/book</loc>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://evera.world/book"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://evera.world/en/book"/>
+  </url>
+  <url>
+    <loc>https://evera.world/en/book</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://evera.world/en/book"/>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://evera.world/book"/>
+  </url>
+  <url>
+    <loc>https://evera.world/b2b</loc>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://evera.world/b2b"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://evera.world/en/b2b"/>
+  </url>
+  <url>
+    <loc>https://evera.world/en/b2b</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://evera.world/en/b2b"/>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://evera.world/b2b"/>
+  </url>
+  <url>
+    <loc>https://evera.world/eternals</loc>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://evera.world/eternals"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://evera.world/en/eternals"/>
+  </url>
+  <url>
+    <loc>https://evera.world/en/eternals</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://evera.world/en/eternals"/>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://evera.world/eternals"/>
+  </url>
+  <url>
+    <loc>https://evera.world/pricing</loc>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://evera.world/pricing"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://evera.world/en/pricing"/>
+  </url>
+  <url>
+    <loc>https://evera.world/en/pricing</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://evera.world/en/pricing"/>
+    <xhtml:link rel="alternate" hreflang="ru" href="https://evera.world/pricing"/>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- create dedicated English versions of the landing and inner pages with localized metadata, open graph, and twitter cards
- simplify Russian pages by removing inline language toggles, updating canonical/alternate links, and wiring language selectors to paired URLs
- enhance the language switcher script to persist preferences, set the document lang attribute, and redirect between RU/EN pages; refresh the sitemap with hreflang alternates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e225e3b28c832fba1d492233ecd566