### PR TITLE
Add SEO metadata to 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,7 +3,19 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Страница не найдена. Возможно, она ещё строится в звёздной пыли.">
+  <meta name="robots" content="noindex, nofollow">
   <title>Страница не найдена | EVERA</title>
+  <link rel="canonical" href="https://evera.world/404">
+  <meta property="og:title" content="Страница не найдена | EVERA">
+  <meta property="og:description" content="Страница не найдена. Возможно, она ещё строится в звёздной пыли.">
+  <meta property="og:image" content="https://evera.world/evera-logo-white.png">
+  <meta property="og:url" content="https://evera.world/404">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Страница не найдена | EVERA">
+  <meta name="twitter:description" content="Страница не найдена. Возможно, она ещё строится в звёздной пыли.">
+  <meta name="twitter:image" content="https://evera.world/evera-logo-white.png">
+  <meta name="twitter:url" content="https://evera.world/404">
   <link rel="icon" href="/evera-logo-white.svg">
   <link rel="stylesheet" href="/css/styles.css">
   <style>.hero{padding:120px 0 60px;text-align:center}</style>


### PR DESCRIPTION
## Summary
- add descriptive, social, and canonical meta tags to the 404 error page
- mark the page as noindex to avoid search engine indexing
- keep existing favicon and stylesheet references for hosting compatibility

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e225e99e84832f8a734605b4c52b96