### PR TITLE
Add descriptive alt text for process icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,7 +273,7 @@
           <div class="process reveal-stagger">
             <div class="step">
               <div class="step-icon">
-                <img src="/assets/icons/interview.svg" alt="" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Ccircle%20cx%3D%2212%22%20cy%3D%229%22%20r%3D%224%22/%3E%3Cpath%20d%3D%22M8%2015c0%202.209%201.791%204%204%204s4-1.791%204-4%22/%3E%3Cpath%20d%3D%22M5%205l2.5%202.5M19%205l-2.5%202.5%22/%3E%3C/svg%3E';">
+                <img src="/assets/icons/interview.svg" alt="Интервью" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Ccircle%20cx%3D%2212%22%20cy%3D%229%22%20r%3D%224%22/%3E%3Cpath%20d%3D%22M8%2015c0%202.209%201.791%204%204%204s4-1.791%204-4%22/%3E%3Cpath%20d%3D%22M5%205l2.5%202.5M19%205l-2.5%202.5%22/%3E%3C/svg%3E';">
               </div>
               <div class="step-content">
                 <b>Интервью: 150+ вопросов</b><br>
@@ -284,7 +284,7 @@
             </div>
             <div class="step">
               <div class="step-icon">
-                <img src="/assets/icons/analysis.svg" alt="" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22M4%2015l4-4%203%203%205-5%204%204%22/%3E%3Cpath%20d%3D%22M4%204h16v16H4z%22/%3E%3C/svg%3E';">
+                <img src="/assets/icons/analysis.svg" alt="Аналитика" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22M4%2015l4-4%203%203%205-5%204%204%22/%3E%3Cpath%20d%3D%22M4%204h16v16H4z%22/%3E%3C/svg%3E';">
               </div>
               <div class="step-content">
                 <b>Аналитика: лексика, эмоции, структура</b><br>
@@ -295,7 +295,7 @@
             </div>
             <div class="step">
               <div class="step-icon">
-                <img src="/assets/icons/dialog.svg" alt="" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22M5%205h14v8H9l-4%204z%22/%3E%3Cpath%20d%3D%22M9%2015v4l4-4h6v4l-4%204v-4H9z%22/%3E%3C/svg%3E';">
+                <img src="/assets/icons/dialog.svg" alt="Диалог" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22M5%205h14v8H9l-4%204z%22/%3E%3Cpath%20d%3D%22M9%2015v4l4-4h6v4l-4%204v-4H9z%22/%3E%3C/svg%3E';">
               </div>
               <div class="step-content">
                 <b>Диалоговый слой: голос, стиль, доступ</b><br>
@@ -318,7 +318,7 @@
           <div class="process reveal-stagger">
             <div class="step">
               <div class="step-icon">
-                <img src="/assets/icons/interview.svg" alt="" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Ccircle%20cx%3D%2212%22%20cy%3D%229%22%20r%3D%224%22/%3E%3Cpath%20d%3D%22M8%2015c0%202.209%201.791%204%204%204s4-1.791%204-4%22/%3E%3Cpath%20d%3D%22M5%205l2.5%202.5M19%205l-2.5%202.5%22/%3E%3C/svg%3E';">
+                <img src="/assets/icons/interview.svg" alt="Interview" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Ccircle%20cx%3D%2212%22%20cy%3D%229%22%20r%3D%224%22/%3E%3Cpath%20d%3D%22M8%2015c0%202.209%201.791%204%204%204s4-1.791%204-4%22/%3E%3Cpath%20d%3D%22M5%205l2.5%202.5M19%205l-2.5%202.5%22/%3E%3C/svg%3E';">
               </div>
               <div class="step-content">
                 <b>Interviews: 150+ prompts</b><br>
@@ -329,7 +329,7 @@
             </div>
             <div class="step">
               <div class="step-icon">
-                <img src="/assets/icons/analysis.svg" alt="" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22M4%2015l4-4%203%203%205-5%204%204%22/%3E%3Cpath%20d%3D%22M4%204h16v16H4z%22/%3E%3C/svg%3E';">
+                <img src="/assets/icons/analysis.svg" alt="Analytics" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22M4%2015l4-4%203%203%205-5%204%204%22/%3E%3Cpath%20d%3D%22M4%204h16v16H4z%22/%3E%3C/svg%3E';">
               </div>
               <div class="step-content">
                 <b>Analytics: lexicon, emotion, structure</b><br>
@@ -340,7 +340,7 @@
             </div>
             <div class="step">
               <div class="step-icon">
-                <img src="/assets/icons/dialog.svg" alt="" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22M5%205h14v8H9l-4%204z%22/%3E%3Cpath%20d%3D%22M9%2015v4l4-4h6v4l-4%204v-4H9z%22/%3E%3C/svg%3E';">
+                <img src="/assets/icons/dialog.svg" alt="Dialogue" width="28" height="28" loading="lazy" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%237CE3FF%22%20stroke-width%3D%221.8%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22M5%205h14v8H9l-4%204z%22/%3E%3Cpath%20d%3D%22M9%2015v4l4-4h6v4l-4%204v-4H9z%22/%3E%3C/svg%3E';">
               </div>
               <div class="step-content">
                 <b>Dialogue layer: voice, style, access</b><br>


### PR DESCRIPTION
## Summary
- add meaningful Russian alt text to the interview, analysis, and dialogue icons in the process section
- mirror the descriptive alt text in the English language variant of the process section

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e225eb62a4832fbbbec4a633456afa