### PR TITLE
Add canonical and social meta tags to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,16 +13,24 @@
   -->
   <meta name="description" content="EVERA - цифровой портрет личности с живым диалогом. Интервью 150+ вопросов, аналитика речи, Книга Жизни, Библиотека Вечных. Безопасно, этично и навсегда.">
   <meta name="keywords" content="цифровое бессмертие, цифровой портрет, оцифровка памяти, цифровое наследие, Книга Жизни, Библиотека Вечных, голосовой портрет, 150 вопросов, лексика и эмоции, этика и безопасность">
+  <link rel="canonical" href="https://evera.world/">
   <!-- Favicon & manifest -->
   <!-- Use relative paths so the site works on GitHub Pages and custom domains -->
   <link rel="icon" href="evera-logo-white.svg">
   <link rel="manifest" href="manifest.json">
   <!-- OpenGraph tags -->
+  <meta property="og:url" content="https://evera.world/">
   <meta property="og:title" content="EVERA | Живая память и цифровое бессмертие">
   <meta property="og:description" content="Интервью 150+ вопросов, анализ речи и эмоций, «Книга Жизни» и Библиотека «Вечных». Сохраняем голос и смысл, чтобы говорить через годы.">
   <!-- PNG превью: стоит подготовить версии в WebP/AVIF с fallbacks -->
   <meta property="og:image" content="evera-logo-white.png">
   <meta property="og:type" content="website">
+  <meta property="og:locale" content="ru_RU">
+  <meta property="og:locale:alternate" content="en_US">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="EVERA | Живая память и цифровое бессмертие">
+  <meta name="twitter:description" content="Интервью 150+ вопросов, анализ речи и эмоций, «Книга Жизни» и Библиотека «Вечных». Сохраняем голос и смысл, чтобы говорить через годы.">
+  <meta name="twitter:image" content="evera-logo-white.png">
   <!-- Stylesheet for this page -->
   <link rel="stylesheet" href="css/styles.css">
 </head>


### PR DESCRIPTION
## Summary
- add canonical URL and Open Graph URL tags pointing to the primary domain
- include locale metadata and Twitter card tags for social sharing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e225ecf288832f9929558b37e12be5