### PR TITLE
Add Yandex.Metrika counter to public pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -21,6 +21,31 @@
   <style>.hero{padding:120px 0 60px;text-align:center}</style>
 </head>
 <body>
+  
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+      m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+      m[i].l=1*new Date();
+      k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+      k.async=1;
+      k.src=r;
+      a.parentNode.insertBefore(k,a);
+    })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js?id=104389952", "ym");
+
+    ym(104389952, "init", {
+      ssr: true,
+      webvisor: true,
+      clickmap: true,
+      ecommerce: "dataLayer",
+      accurateTrackBounce: true,
+      trackLinks: true
+    });
+  </script>
+  <noscript>
+    <div>
+      <img src="https://mc.yandex.ru/watch/104389952" style="position:absolute; left:-9999px;" alt="" />
+    </div>
+  </noscript>
   <canvas id="stars" aria-hidden="true"></canvas>
   <main class="container hero">
     <h1>404: портал сюда не ведёт</h1>

--- a/en/index.html
+++ b/en/index.html
@@ -30,6 +30,31 @@
   <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="home">
+  
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+      m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+      m[i].l=1*new Date();
+      k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+      k.async=1;
+      k.src=r;
+      a.parentNode.insertBefore(k,a);
+    })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js?id=104389952", "ym");
+
+    ym(104389952, "init", {
+      ssr: true,
+      webvisor: true,
+      clickmap: true,
+      ecommerce: "dataLayer",
+      accurateTrackBounce: true,
+      trackLinks: true
+    });
+  </script>
+  <noscript>
+    <div>
+      <img src="https://mc.yandex.ru/watch/104389952" style="position:absolute; left:-9999px;" alt="" />
+    </div>
+  </noscript>
   <div class="read-progress" id="readProgress" aria-hidden="true"></div>
   <!-- Туманность с наложением. Располагается под слоем звёзд. -->
   <canvas id="nebula" data-parallax-speed="0.006" aria-hidden="true"></canvas>

--- a/en/pages/b2b.html
+++ b/en/pages/b2b.html
@@ -20,6 +20,31 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="b2b">
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+      m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+      m[i].l=1*new Date();
+      k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+      k.async=1;
+      k.src=r;
+      a.parentNode.insertBefore(k,a);
+    })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js?id=104389952", "ym");
+
+    ym(104389952, "init", {
+      ssr: true,
+      webvisor: true,
+      clickmap: true,
+      ecommerce: "dataLayer",
+      accurateTrackBounce: true,
+      trackLinks: true
+    });
+  </script>
+  <noscript>
+    <div>
+      <img src="https://mc.yandex.ru/watch/104389952" style="position:absolute; left:-9999px;" alt="" />
+    </div>
+  </noscript>
+
 <div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>

--- a/en/pages/book.html
+++ b/en/pages/book.html
@@ -20,6 +20,31 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="book">
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+      m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+      m[i].l=1*new Date();
+      k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+      k.async=1;
+      k.src=r;
+      a.parentNode.insertBefore(k,a);
+    })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js?id=104389952", "ym");
+
+    ym(104389952, "init", {
+      ssr: true,
+      webvisor: true,
+      clickmap: true,
+      ecommerce: "dataLayer",
+      accurateTrackBounce: true,
+      trackLinks: true
+    });
+  </script>
+  <noscript>
+    <div>
+      <img src="https://mc.yandex.ru/watch/104389952" style="position:absolute; left:-9999px;" alt="" />
+    </div>
+  </noscript>
+
 <div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>

--- a/en/pages/cases.html
+++ b/en/pages/cases.html
@@ -20,6 +20,31 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="cases">
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+      m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+      m[i].l=1*new Date();
+      k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+      k.async=1;
+      k.src=r;
+      a.parentNode.insertBefore(k,a);
+    })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js?id=104389952", "ym");
+
+    ym(104389952, "init", {
+      ssr: true,
+      webvisor: true,
+      clickmap: true,
+      ecommerce: "dataLayer",
+      accurateTrackBounce: true,
+      trackLinks: true
+    });
+  </script>
+  <noscript>
+    <div>
+      <img src="https://mc.yandex.ru/watch/104389952" style="position:absolute; left:-9999px;" alt="" />
+    </div>
+  </noscript>
+
 <div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>

--- a/en/pages/eternals.html
+++ b/en/pages/eternals.html
@@ -20,6 +20,31 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="eternals">
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+      m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+      m[i].l=1*new Date();
+      k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+      k.async=1;
+      k.src=r;
+      a.parentNode.insertBefore(k,a);
+    })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js?id=104389952", "ym");
+
+    ym(104389952, "init", {
+      ssr: true,
+      webvisor: true,
+      clickmap: true,
+      ecommerce: "dataLayer",
+      accurateTrackBounce: true,
+      trackLinks: true
+    });
+  </script>
+  <noscript>
+    <div>
+      <img src="https://mc.yandex.ru/watch/104389952" style="position:absolute; left:-9999px;" alt="" />
+    </div>
+  </noscript>
+
 <div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>

--- a/en/pages/methodology.html
+++ b/en/pages/methodology.html
@@ -20,6 +20,31 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="methodology">
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+      m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+      m[i].l=1*new Date();
+      k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+      k.async=1;
+      k.src=r;
+      a.parentNode.insertBefore(k,a);
+    })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js?id=104389952", "ym");
+
+    ym(104389952, "init", {
+      ssr: true,
+      webvisor: true,
+      clickmap: true,
+      ecommerce: "dataLayer",
+      accurateTrackBounce: true,
+      trackLinks: true
+    });
+  </script>
+  <noscript>
+    <div>
+      <img src="https://mc.yandex.ru/watch/104389952" style="position:absolute; left:-9999px;" alt="" />
+    </div>
+  </noscript>
+
 <div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>

--- a/en/pages/pricing.html
+++ b/en/pages/pricing.html
@@ -20,6 +20,31 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="pricing">
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+      m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+      m[i].l=1*new Date();
+      k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+      k.async=1;
+      k.src=r;
+      a.parentNode.insertBefore(k,a);
+    })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js?id=104389952", "ym");
+
+    ym(104389952, "init", {
+      ssr: true,
+      webvisor: true,
+      clickmap: true,
+      ecommerce: "dataLayer",
+      accurateTrackBounce: true,
+      trackLinks: true
+    });
+  </script>
+  <noscript>
+    <div>
+      <img src="https://mc.yandex.ru/watch/104389952" style="position:absolute; left:-9999px;" alt="" />
+    </div>
+  </noscript>
+
 <div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>

--- a/en/pages/roadmap.html
+++ b/en/pages/roadmap.html
@@ -20,6 +20,31 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="roadmap">
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+      m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+      m[i].l=1*new Date();
+      k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+      k.async=1;
+      k.src=r;
+      a.parentNode.insertBefore(k,a);
+    })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js?id=104389952", "ym");
+
+    ym(104389952, "init", {
+      ssr: true,
+      webvisor: true,
+      clickmap: true,
+      ecommerce: "dataLayer",
+      accurateTrackBounce: true,
+      trackLinks: true
+    });
+  </script>
+  <noscript>
+    <div>
+      <img src="https://mc.yandex.ru/watch/104389952" style="position:absolute; left:-9999px;" alt="" />
+    </div>
+  </noscript>
+
 <div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>

--- a/en/pages/team.html
+++ b/en/pages/team.html
@@ -20,6 +20,31 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="team">
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+      m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+      m[i].l=1*new Date();
+      k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+      k.async=1;
+      k.src=r;
+      a.parentNode.insertBefore(k,a);
+    })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js?id=104389952", "ym");
+
+    ym(104389952, "init", {
+      ssr: true,
+      webvisor: true,
+      clickmap: true,
+      ecommerce: "dataLayer",
+      accurateTrackBounce: true,
+      trackLinks: true
+    });
+  </script>
+  <noscript>
+    <div>
+      <img src="https://mc.yandex.ru/watch/104389952" style="position:absolute; left:-9999px;" alt="" />
+    </div>
+  </noscript>
+
 <div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
   -->
   <meta name="description" content="EVERA - цифровой портрет личности с живым диалогом. Интервью 150+ вопросов, аналитика речи, Книга Жизни, Библиотека Вечных. Безопасно, этично и навсегда.">
   <meta name="keywords" content="цифровое бессмертие, цифровой портрет, оцифровка памяти, цифровое наследие, Книга Жизни, Библиотека Вечных, голосовой портрет, 150 вопросов, лексика и эмоции, этика и безопасность">
-  <link rel="canonical" href="https://evera.world/">
   <!-- Favicon & manifest -->
   <!-- Use relative paths so the site works on GitHub Pages and custom domains -->
   <link rel="icon" href="evera-logo-white.svg">
@@ -38,6 +37,31 @@
   <link rel="stylesheet" href="css/styles.css">
 </head>
 <body data-nebula="home">
+  
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+      m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+      m[i].l=1*new Date();
+      k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+      k.async=1;
+      k.src=r;
+      a.parentNode.insertBefore(k,a);
+    })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js?id=104389952", "ym");
+
+    ym(104389952, "init", {
+      ssr: true,
+      webvisor: true,
+      clickmap: true,
+      ecommerce: "dataLayer",
+      accurateTrackBounce: true,
+      trackLinks: true
+    });
+  </script>
+  <noscript>
+    <div>
+      <img src="https://mc.yandex.ru/watch/104389952" style="position:absolute; left:-9999px;" alt="" />
+    </div>
+  </noscript>
   <div class="read-progress" id="readProgress" aria-hidden="true"></div>
   <!-- Туманность с наложением. Располагается под слоем звёзд. -->
   <canvas id="nebula" data-parallax-speed="0.006" aria-hidden="true"></canvas>

--- a/pages/b2b.html
+++ b/pages/b2b.html
@@ -11,6 +11,32 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="b2b">
+  
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+      m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+      m[i].l=1*new Date();
+      k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+      k.async=1;
+      k.src=r;
+      a.parentNode.insertBefore(k,a);
+    })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js?id=104389952", "ym");
+
+    ym(104389952, "init", {
+      ssr: true,
+      webvisor: true,
+      clickmap: true,
+      ecommerce: "dataLayer",
+      accurateTrackBounce: true,
+      trackLinks: true
+    });
+  </script>
+  <noscript>
+    <div>
+      <img src="https://mc.yandex.ru/watch/104389952" style="position:absolute; left:-9999px;" alt="" />
+    </div>
+  </noscript>
+
 <div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>

--- a/pages/book.html
+++ b/pages/book.html
@@ -11,6 +11,32 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="book">
+  
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+      m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+      m[i].l=1*new Date();
+      k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+      k.async=1;
+      k.src=r;
+      a.parentNode.insertBefore(k,a);
+    })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js?id=104389952", "ym");
+
+    ym(104389952, "init", {
+      ssr: true,
+      webvisor: true,
+      clickmap: true,
+      ecommerce: "dataLayer",
+      accurateTrackBounce: true,
+      trackLinks: true
+    });
+  </script>
+  <noscript>
+    <div>
+      <img src="https://mc.yandex.ru/watch/104389952" style="position:absolute; left:-9999px;" alt="" />
+    </div>
+  </noscript>
+
 <div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>

--- a/pages/cases.html
+++ b/pages/cases.html
@@ -11,6 +11,32 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="cases">
+  
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+      m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+      m[i].l=1*new Date();
+      k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+      k.async=1;
+      k.src=r;
+      a.parentNode.insertBefore(k,a);
+    })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js?id=104389952", "ym");
+
+    ym(104389952, "init", {
+      ssr: true,
+      webvisor: true,
+      clickmap: true,
+      ecommerce: "dataLayer",
+      accurateTrackBounce: true,
+      trackLinks: true
+    });
+  </script>
+  <noscript>
+    <div>
+      <img src="https://mc.yandex.ru/watch/104389952" style="position:absolute; left:-9999px;" alt="" />
+    </div>
+  </noscript>
+
 <div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>

--- a/pages/eternals.html
+++ b/pages/eternals.html
@@ -11,6 +11,32 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="eternals">
+  
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+      m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+      m[i].l=1*new Date();
+      k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+      k.async=1;
+      k.src=r;
+      a.parentNode.insertBefore(k,a);
+    })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js?id=104389952", "ym");
+
+    ym(104389952, "init", {
+      ssr: true,
+      webvisor: true,
+      clickmap: true,
+      ecommerce: "dataLayer",
+      accurateTrackBounce: true,
+      trackLinks: true
+    });
+  </script>
+  <noscript>
+    <div>
+      <img src="https://mc.yandex.ru/watch/104389952" style="position:absolute; left:-9999px;" alt="" />
+    </div>
+  </noscript>
+
 <div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>

--- a/pages/methodology.html
+++ b/pages/methodology.html
@@ -11,6 +11,32 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="methodology">
+  
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+      m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+      m[i].l=1*new Date();
+      k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+      k.async=1;
+      k.src=r;
+      a.parentNode.insertBefore(k,a);
+    })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js?id=104389952", "ym");
+
+    ym(104389952, "init", {
+      ssr: true,
+      webvisor: true,
+      clickmap: true,
+      ecommerce: "dataLayer",
+      accurateTrackBounce: true,
+      trackLinks: true
+    });
+  </script>
+  <noscript>
+    <div>
+      <img src="https://mc.yandex.ru/watch/104389952" style="position:absolute; left:-9999px;" alt="" />
+    </div>
+  </noscript>
+
 <div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>

--- a/pages/pricing.html
+++ b/pages/pricing.html
@@ -11,6 +11,32 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="pricing">
+  
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+      m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+      m[i].l=1*new Date();
+      k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+      k.async=1;
+      k.src=r;
+      a.parentNode.insertBefore(k,a);
+    })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js?id=104389952", "ym");
+
+    ym(104389952, "init", {
+      ssr: true,
+      webvisor: true,
+      clickmap: true,
+      ecommerce: "dataLayer",
+      accurateTrackBounce: true,
+      trackLinks: true
+    });
+  </script>
+  <noscript>
+    <div>
+      <img src="https://mc.yandex.ru/watch/104389952" style="position:absolute; left:-9999px;" alt="" />
+    </div>
+  </noscript>
+
 <div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>

--- a/pages/roadmap.html
+++ b/pages/roadmap.html
@@ -11,6 +11,32 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="roadmap">
+  
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+      m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+      m[i].l=1*new Date();
+      k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+      k.async=1;
+      k.src=r;
+      a.parentNode.insertBefore(k,a);
+    })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js?id=104389952", "ym");
+
+    ym(104389952, "init", {
+      ssr: true,
+      webvisor: true,
+      clickmap: true,
+      ecommerce: "dataLayer",
+      accurateTrackBounce: true,
+      trackLinks: true
+    });
+  </script>
+  <noscript>
+    <div>
+      <img src="https://mc.yandex.ru/watch/104389952" style="position:absolute; left:-9999px;" alt="" />
+    </div>
+  </noscript>
+
 <div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>

--- a/pages/team.html
+++ b/pages/team.html
@@ -11,6 +11,32 @@
 <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body data-nebula="team">
+  
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+      m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+      m[i].l=1*new Date();
+      k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+      k.async=1;
+      k.src=r;
+      a.parentNode.insertBefore(k,a);
+    })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js?id=104389952", "ym");
+
+    ym(104389952, "init", {
+      ssr: true,
+      webvisor: true,
+      clickmap: true,
+      ecommerce: "dataLayer",
+      accurateTrackBounce: true,
+      trackLinks: true
+    });
+  </script>
+  <noscript>
+    <div>
+      <img src="https://mc.yandex.ru/watch/104389952" style="position:absolute; left:-9999px;" alt="" />
+    </div>
+  </noscript>
+
 <div class="read-progress" id="readProgress" aria-hidden="true"></div>
 <canvas id="nebula" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>

--- a/yandex_3dd1afb61f3e09a1.html
+++ b/yandex_3dd1afb61f3e09a1.html
@@ -1,6 +1,34 @@
 <html>
-    <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    </head>
-    <body>Verification: 3dd1afb61f3e09a1</body>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  </head>
+  <body>
+    
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+      m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+      m[i].l=1*new Date();
+      k=e.createElement(t),a=e.getElementsByTagName(t)[0];
+      k.async=1;
+      k.src=r;
+      a.parentNode.insertBefore(k,a);
+    })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js?id=104389952", "ym");
+
+    ym(104389952, "init", {
+      ssr: true,
+      webvisor: true,
+      clickmap: true,
+      ecommerce: "dataLayer",
+      accurateTrackBounce: true,
+      trackLinks: true
+    });
+  </script>
+  <noscript>
+    <div>
+      <img src="https://mc.yandex.ru/watch/104389952" style="position:absolute; left:-9999px;" alt="" />
+    </div>
+  </noscript>
+
+    Verification: 3dd1afb61f3e09a1
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- add the Yandex.Metrika tracking snippet to every Russian and English HTML page so it loads immediately after `<body>`
- initialize counter 104389952 with SSR, webvisor, click tracking, ecommerce data layer, bounce accuracy, and provide a noscript pixel fallback
- remove the duplicate canonical link on the home page to keep the markup valid

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68e2b383c8ec832fad97c009542f8085