### PR TITLE
Adjust header navigation layout and styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -132,6 +132,13 @@ main, header, footer, section{position:relative;z-index:1}
   width:100%;
 }
 
+.nav__actions{
+  margin-left:auto;
+  display:flex;
+  align-items:center;
+  gap:20px;
+}
+
 @media (min-width:1024px){
   .header .nav.container{
     padding-inline:24px;
@@ -145,24 +152,41 @@ main, header, footer, section{position:relative;z-index:1}
   }
 }
 
-.logo{display:inline-flex;align-items:center;gap:12px;color:var(--text)}
-.logo img{height:26px;width:auto}
+.logo{
+  display:inline-flex;
+  align-items:center;
+  gap:12px;
+  color:var(--text);
+  align-self:center;
+  margin-block:12px;
+  padding:10px 18px;
+  border-radius:18px;
+  background:rgba(12, 30, 51, .5);
+  box-shadow:0 0 24px rgba(124, 227, 255, .28);
+  backdrop-filter:blur(6px);
+}
+.logo img{height:26px;width:auto;filter:drop-shadow(0 0 8px rgba(124,227,255,.45))}
 
 .menu-toggle{
   margin:0;
-  background:transparent;
+  background:rgba(12, 30, 51, .4);
   border:1px solid rgba(124,227,255,.28);
   color:var(--text);
   font-size:24px;
-  padding:10px;
-  border-radius:12px;
+  border-radius:14px;
   cursor:pointer;
   transition:transform .2s ease, border-color .2s ease, background .2s ease;
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  min-width:44px;
-  min-height:44px;
+  width:48px;
+  height:48px;
+  min-width:48px;
+  min-height:48px;
+  inline-size:48px;
+  block-size:48px;
+  min-inline-size:48px;
+  min-block-size:48px;
   line-height:1;
 }
 .menu-toggle:hover{background:rgba(124,227,255,.12);border-color:rgba(124,227,255,.42)}
@@ -171,7 +195,6 @@ main, header, footer, section{position:relative;z-index:1}
 .links{
   display:flex;
   gap:28px;
-  margin-left:auto;
   font-size:15px;
 }
 .links .menu-group{display:flex;gap:18px;align-items:center}
@@ -185,7 +208,6 @@ main, header, footer, section{position:relative;z-index:1}
 }
 @media (max-width:1023px){
   .header .links{display:none}
-  .menu-toggle{margin-left:auto}
 }
 
 @media (min-width:1024px){

--- a/index.html
+++ b/index.html
@@ -77,13 +77,13 @@
       <a class="logo" href="#mission" aria-label="EVERA">
         <img src="evera-logo-white.svg" alt="EVERA logo">
       </a>
-      <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню" aria-expanded="false" aria-controls="navDrawer">☰</button>
-      <nav class="links" id="primaryNav" aria-label="Основная навигация">
-        <article lang="ru">
-          <div class="menu-group" aria-label="Навигация по разделам страницы">
-            <a href="#mission" class="active">Главная</a>
-            <a href="#what">Что такое</a>
-            <a href="#process">Процесс</a>
+      <div class="nav__actions">
+        <nav class="links" id="primaryNav" aria-label="Основная навигация">
+          <article lang="ru">
+            <div class="menu-group" aria-label="Навигация по разделам страницы">
+              <a href="#mission" class="active">Главная</a>
+              <a href="#what">Что такое</a>
+              <a href="#process">Процесс</a>
             <a href="#ai">ИИ</a>
             <a href="#book">Книга Жизни</a>
             <a href="#eternals">Вечные</a>
@@ -93,12 +93,14 @@
             <a href="#faq">FAQ</a>
           </div>
         </article>
-        
-      </nav>
-      <select class="lang-switch" aria-label="Переключить язык">
-        <option value="ru" data-url="/index.html" selected>RU</option>
-        <option value="en" data-url="/en/index.html">EN</option>
-      </select>
+
+        </nav>
+        <button id="menuToggle" class="menu-toggle" type="button" aria-label="Меню" aria-expanded="false" aria-controls="navDrawer">☰</button>
+        <select class="lang-switch" aria-label="Переключить язык">
+          <option value="ru" data-url="/index.html" selected>RU</option>
+          <option value="en" data-url="/en/index.html">EN</option>
+        </select>
+      </div>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- reposition the header menu toggle after the navigation links inside a new alignment wrapper
- update navigation and menu toggle styles so the hamburger stays right-aligned with a 48×48px hit area across breakpoints
- enhance the logo with added spacing, vertical centering, and a subtle translucent glow treatment

## Testing
- Manual verification in Playwright (scroll + menu toggle)


------
https://chatgpt.com/codex/tasks/task_e_68e3899cebc0832f809679ef03eca14d