### PR TITLE
Update hero typography and CTA styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -345,7 +345,12 @@ main, header, footer, section{position:relative;z-index:1}
   -webkit-backdrop-filter:blur(22px) saturate(160%);
   box-shadow:0 32px 80px rgba(5,14,32,.35);
 }
-.hero h1{font-size:var(--h1); line-height:1.15; margin:0;}
+.hero h1{font-size:var(--h1); line-height:1.25; margin:0;}
+.hero-title{margin:0;}
+.hero-title__line{display:block;}
+.hero-title__line--brand{font-weight:500;}
+.hero-title__line--memory{font-weight:600;}
+.hero-title__line--eternity{font-weight:700;color:#00BFFF;}
 .hero .lead{margin:0;color:var(--muted)}
 
 p{font-size:var(--body); line-height:var(--lh); color:var(--text); margin:0;}
@@ -522,6 +527,33 @@ h3{font-size:var(--h3); line-height:1.3; margin:0;}
 .btn:hover::after,.btn:focus-visible::after{ transform:translateX(100%) }
 .btn.ghost{background:transparent;border-color:rgba(124,227,255,.25);color:var(--muted)}
 .btn.ghost:hover,.btn.ghost:focus-visible{color:var(--text);background:rgba(12,30,51,.4)}
+
+.hero .btn{
+  background:#00BFFF;
+  color:#04111E;
+  border-color:rgba(0,191,255,.7);
+  box-shadow:0 12px 30px rgba(0,191,255,.25);
+}
+.hero .btn:hover,
+.hero .btn:focus-visible{
+  background:#33D6FF;
+  color:#04111E;
+  border-color:rgba(0,191,255,.85);
+  box-shadow:0 0 24px rgba(0,191,255,.45), 0 12px 34px rgba(0,191,255,.28);
+}
+.hero .btn.ghost{
+  background:transparent;
+  color:#00BFFF;
+  border-color:rgba(0,191,255,.6);
+  box-shadow:none;
+}
+.hero .btn.ghost:hover,
+.hero .btn.ghost:focus-visible{
+  color:#E6EEF7;
+  background:rgba(0,191,255,.12);
+  border-color:rgba(0,191,255,.85);
+  box-shadow:0 0 18px rgba(0,191,255,.35);
+}
 
 .stat-grid{
   display:grid;

--- a/index.html
+++ b/index.html
@@ -162,7 +162,11 @@
       <article lang="ru">
         <div class="container reveal stack" data-parallax-speed="0.01">
           <div class="overlay stack">
-            <h1>EVERA<br>Живая память<br>Портал в вечность</h1>
+            <h1 class="hero-title">
+              <span class="hero-title__line hero-title__line--brand">EVERA</span>
+              <span class="hero-title__line hero-title__line--memory">Живая память</span>
+              <span class="hero-title__line hero-title__line--eternity">Портал в вечность</span>
+            </h1>
             <p class="lead">
               Мы сохраняем голос, истории и ценности, чтобы потомки могли разговаривать с вами через годы.
               Интервью 150+ вопросов, аналитика речи и «Книга Жизни» превращают память в живой диалог.


### PR DESCRIPTION
## Summary
- wrap each hero headline line with span classes for targeted styling and adjust line-height
- refine hero title weights and highlight the closing line with accent colour
- restyle primary and secondary hero CTAs with lighter backgrounds, outline treatment, and hover glow that meets contrast guidelines

## Testing
- python -m http.server 8000 (manual visual check)


------
https://chatgpt.com/codex/tasks/task_e_68e38b020308832fbc410d5e540d966a