### PR TITLE
Adjust spacing scale and hero overlay styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -13,15 +13,15 @@
   --h3:22px;
   --body:17px;
   --lh:1.6;
-  --space-section:96px;
-  --space-section-m:56px;
-  --space-2:8px;
-  --space-3:12px;
-  --space-4:16px;
-  --space-5:20px;
-  --space-6:24px;
-  --space-7:28px;
-  --space-8:32px;
+  --space-section:108px;
+  --space-section-m:62px;
+  --space-2:9px;
+  --space-3:14px;
+  --space-4:18px;
+  --space-5:22px;
+  --space-6:27px;
+  --space-7:32px;
+  --space-8:36px;
 
   /* Motion */
   --reveal-dur:480ms;
@@ -335,15 +335,16 @@ main, header, footer, section{position:relative;z-index:1}
 .section > .container.stack{--stack-gap:var(--space-6);}
 .overlay.stack{--stack-gap:var(--space-5);}
 
-.hero{padding-top:140px}
+.hero{padding-top:calc(var(--space-section) + 32px)}
 .hero .overlay{
-  background:rgba(12,30,51,.32);
+  background:rgba(18,40,70,.38);
   border:1px solid rgba(124,227,255,.22);
   border-radius:20px;
-  padding:48px clamp(24px, 6vw, 64px);
+  padding-block:56px;
+  padding-inline:clamp(28px, 6vw, 72px);
   backdrop-filter:blur(22px) saturate(160%);
   -webkit-backdrop-filter:blur(22px) saturate(160%);
-  box-shadow:0 32px 80px rgba(5,14,32,.35);
+  box-shadow:0 32px 80px rgba(5,14,32,.35), inset 0 0 20px rgba(255,255,255,.05);
 }
 .hero h1{font-size:var(--h1); line-height:1.25; margin:0;}
 .hero-title{margin:0;}
@@ -657,14 +658,20 @@ dialog .modal-actions .btn + .btn{margin-top:0;}
 .reveal-stagger.reveal--visible > *:nth-child(6){transition-delay:calc(var(--reveal-stagger)*5)}
 
 @media (max-width:768px){
-  .hero{padding-top:120px}
-  .hero .overlay{padding:40px 24px}
+  .hero{padding-top:calc(var(--space-section-m) + 40px)}
+  .hero .overlay{
+    padding-block:44px;
+    padding-inline:24px;
+  }
   .cta{justify-content:flex-start}
 }
 
 @media (max-width:600px){
   .nav{gap:var(--space-4);}
-  .hero .overlay{padding:36px 20px}
+  .hero .overlay{
+    padding-block:38px;
+    padding-inline:20px;
+  }
   .cta{--stack-gap:var(--space-4);}
   .cta-actions{flex-direction:column;align-items:stretch;gap:var(--space-3);}
 }


### PR DESCRIPTION
## Summary
- increase the global spacing scale to give sections and cards more breathing room
- brighten the hero overlay, add a subtle inset glow, and retune padding across breakpoints for cleaner baselines

## Testing
- Manual visual check: index.html
- Manual visual check: pages/team.html

------
https://chatgpt.com/codex/tasks/task_e_68e3928933f4832fb8d39f6ae91e057c