### PR TITLE
Refine hero stats and add collapsible metrics

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -565,16 +565,60 @@ h3{font-size:var(--h3); line-height:1.3; margin:0;}
 @media (max-width:1024px){ .stat-grid{grid-template-columns:repeat(2,1fr)} }
 @media (max-width:640px){ .stat-grid{grid-template-columns:1fr} }
 .stat{
-  border:1px solid rgba(124,227,255,.18);
-  background:rgba(12,30,51,.25);
+  --stat-bg:rgba(12,30,51,.25);
+  --stat-border:rgba(124,227,255,.18);
+  --stat-accent:var(--accent);
+  border:1px solid var(--stat-border);
+  background:var(--stat-bg);
   backdrop-filter:blur(4px);
-  padding:var(--space-4);
+  padding:var(--space-4) var(--space-5);
   border-radius:12px;
   transition:transform .2s ease, box-shadow .2s ease, border-color .2s ease;
   color:var(--muted);
+  line-height:1.45;
 }
-.stat b{display:inline-block; margin-right:6px; color:var(--accent)}
+.stat b{display:inline-block; margin-right:6px; color:var(--stat-accent)}
 .stat:where(:hover,:focus-within){ transform:translateY(-4px); box-shadow:0 8px 24px rgba(124,227,255,.08) }
+
+.stat--blue{
+  --stat-bg:rgba(0,191,255,.12);
+  --stat-border:rgba(0,191,255,.35);
+  --stat-accent:#33D6FF;
+}
+
+.stat--green{
+  --stat-bg:rgba(33,217,176,.12);
+  --stat-border:rgba(48,242,162,.32);
+  --stat-accent:#30F2A2;
+}
+
+.stat--violet{
+  --stat-bg:rgba(136,101,255,.12);
+  --stat-border:rgba(179,140,255,.32);
+  --stat-accent:#B38CFF;
+}
+
+.stat-details{margin-top:var(--space-3); width:100%;}
+.stat-details__summary{
+  cursor:pointer;
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  color:var(--accent);
+  font-weight:600;
+  padding:8px 0;
+  line-height:1.4;
+}
+.stat-details__summary::marker{display:none;}
+.stat-details__summary::-webkit-details-marker{display:none;}
+.stat-details[open] .stat-details__summary{color:var(--text);}
+.stat-grid--extended{
+  margin-top:var(--space-3);
+  grid-template-columns:repeat(2,minmax(0,1fr));
+}
+@media (max-width:640px){
+  .stat-grid--extended{grid-template-columns:1fr;}
+}
 
 .process{display:grid;gap:var(--space-4);margin-top:0;}
 @media (min-width:768px){.process{grid-template-columns:repeat(3,minmax(0,1fr))}}

--- a/index.html
+++ b/index.html
@@ -176,13 +176,20 @@
               <a class="btn ghost" href="https://t.me/sololabschannel" target="_blank" rel="noopener">Telegram-канал</a>
             </div>
             <div class="stat-grid reveal-stagger">
-              <div class="stat"><b>150+</b>вопросов в глубинном интервью</div>
-              <div class="stat"><b>1&nbsp;млн+</b>слов&nbsp;— минимальный объём данных</div>
-              <div class="stat"><b>24/7</b>доступ к цифровому портрету</div>
-              <div class="stat"><b>100%</b>контроль приватности и доступов</div>
-              <div class="stat"><b>20+</b>эмоциональных и метрических метрик</div>
-              <div class="stat">Издание «Книга Жизни» на основе биографии</div>
+              <div class="stat stat--blue"><b>150+</b>вопросов в глубинном интервью</div>
+              <div class="stat stat--green"><b>1&nbsp;млн+</b>слов&nbsp;— минимальный объём данных</div>
+              <div class="stat stat--violet"><b>24/7</b>доступ к цифровому портрету</div>
+              <div class="stat stat--green"><b>100%</b>контроль приватности и доступов</div>
             </div>
+            <details class="stat-details">
+              <summary class="stat-details__summary">+ Подробнее</summary>
+              <div class="stat-grid stat-grid--extended">
+                <div class="stat stat--violet"><b>20+</b>эмоциональных и метрических метрик</div>
+                <div class="stat stat--blue">Издание «Книга&nbsp;Жизни» на основе биографии</div>
+                <div class="stat stat--green">Голосовой ИИ-модуль с личной лексикой и стилем</div>
+                <div class="stat stat--violet">Безопасное хранение и передача цифрового наследия</div>
+              </div>
+            </details>
           </div>
         </div>
       </article>


### PR DESCRIPTION
## Summary
- reduce the hero metric grid to four key stats and move the rest into a "+ Подробнее" disclosure
- add themed stat color modifiers and shared spacing variables for consistent line-height and padding
- style the expandable metrics container for accessibility and responsive layouts

## Testing
- Manually viewed index.html in desktop viewport
- Manually viewed index.html in mobile viewport

------
https://chatgpt.com/codex/tasks/task_e_68e3fbae4ebc832fa65298e7ba44d73f