### PR TITLE
Enhance nebula gradients and star distribution

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -51,6 +51,8 @@ body{
 body[data-nebula="home"]{
   color:var(--text);
   background:
+    radial-gradient(420px 320px at 50% 38%, rgba(124,227,255,.16), rgba(7,12,26,0) 72%),
+    radial-gradient(140% 140% at 50% 50%, rgba(7,12,26,0) 58%, rgba(3,6,14,.78) 100%),
     radial-gradient(1200px 800px at 50% 40%, var(--bg-deep-2) 0%, var(--bg-deep-1) 60%, #050914 100%);
 }
 body[data-nebula="home"]::before{


### PR DESCRIPTION
## Summary
- layer additional radial gradients on the home nebula background to darken edges and add a soft core glow
- bias new star positions toward the canvas perimeter and recycle with the same weighting to keep the center clearer
- adjust particle rendering opacity and size based on distance from center to emphasize edge density

## Testing
- python -m http.server 8000 (manual visual inspection at 1440x900, dpr 1)
- python -m http.server 8000 (manual visual inspection at 768x1024, dpr 2)


------
https://chatgpt.com/codex/tasks/task_e_68e3fbb949f0832f852ba43a561d4af7