### PR TITLE
Optimize EVERA logo SVG and standardize typography spacing

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -12,7 +12,7 @@
   --h2:28px;
   --h3:22px;
   --body:17px;
-  --lh:1.6;
+  --lh:1.4;
   --space-section:108px;
   --space-section-m:62px;
   --space-2:9px;
@@ -27,6 +27,7 @@
   --reveal-dur:480ms;
   --reveal-stagger:100ms;
   --glow:0 0 0 transparent;
+  --logo-glow:drop-shadow(0 0 14px rgba(124,227,255,.4));
 }
 @media (max-width: 768px){
   :root{ --h1:clamp(32px,5.5vw,36px); }
@@ -75,6 +76,7 @@ a:focus-visible, button:focus-visible, .btn:focus-visible{
 }
 
 img{max-width:100%;display:block}
+img[src$="evera-logo-white.svg"]{filter:var(--logo-glow);}
 
 main, header, footer, section{position:relative;z-index:1}
 
@@ -165,7 +167,7 @@ main, header, footer, section{position:relative;z-index:1}
   box-shadow:0 0 24px rgba(124, 227, 255, .28);
   backdrop-filter:blur(6px);
 }
-.logo img{height:26px;width:auto;filter:drop-shadow(0 0 8px rgba(124,227,255,.45))}
+.logo img{height:26px;width:auto;}
 
 .menu-toggle{
   margin:0;
@@ -354,7 +356,10 @@ main, header, footer, section{position:relative;z-index:1}
 .hero-title__line--eternity{font-weight:700;color:#00BFFF;}
 .hero .lead{margin:0;color:var(--muted)}
 
-p{font-size:var(--body); line-height:var(--lh); color:var(--text); margin:0;}
+p{font-size:var(--body); line-height:var(--lh); color:var(--text); margin:0 0 1.6em;}
+p:last-child{margin-bottom:0;}
+ul,ol{margin:0 0 1.6em; padding-left:1.25em; line-height:var(--lh);}
+ul:last-child,ol:last-child{margin-bottom:0;}
 
 h2{font-size:var(--h2); line-height:1.25; margin:0;}
 h3{font-size:var(--h3); line-height:1.3; margin:0;}

--- a/evera-logo-white.svg
+++ b/evera-logo-white.svg
@@ -1,105 +1,16 @@
-<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
-  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="696.25pt" height="187.21875pt" viewBox="0 0 696.25 187.21875" xmlns="http://www.w3.org/2000/svg" version="1.1">
- <metadata>
-  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-   <cc:Work>
-    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2025-09-26T08:05:42.690563</dc:date>
-    <dc:format>image/svg+xml</dc:format>
-    <dc:creator>
-     <cc:Agent>
-      <dc:title>Matplotlib v3.6.3, https://matplotlib.org/</dc:title>
-     </cc:Agent>
-    </dc:creator>
-   </cc:Work>
-  </rdf:RDF>
- </metadata>
- <defs>
-  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
- </defs>
- <g id="figure_1">
-  <g id="patch_1">
-   <path d="M 0 187.21875 
-L 696.25 187.21875 
-L 696.25 0 
-L 0 0 
-L 0 187.21875 
-z
-" style="fill: none"/>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="696.25" height="187.21875" viewBox="0 0 696.25 187.21875" role="img" aria-labelledby="evera-logo-title" focusable="false" shape-rendering="geometricPrecision" text-rendering="geometricPrecision" preserveAspectRatio="xMidYMid meet">
+  <title id="evera-logo-title">EVERA logo</title>
+  <defs>
+    <path id="glyph-e" d="M 723 2067 L 3808 2067 L 3808 2483 L 723 2483 L 723 2067 z M 723 4102 L 3808 4102 L 3808 4531 L 723 4531 L 723 4102 z M 723 429 L 3808 429 L 3808 0 L 723 0 L 723 429 z" transform="scale(0.015625)"/>
+    <path id="glyph-v" d="M 4467 4480 L 3968 4480 L 2253 614 L 550 4480 L 13 4480 L 1997 0 L 2483 0 L 4467 4480 z" transform="scale(0.015625)"/>
+    <path id="glyph-r" d="M 3226 1536 C 3872 1747 4243 2240 4243 2944 C 4243 3904 3552 4480 2406 4480 L 723 4480 L 723 4051 L 2394 4051 C 3283 4051 3750 3648 3750 2944 C 3750 2240 3283 1837 2394 1837 L 723 1837 L 723 0 L 1216 0 L 1216 1414 L 2406 1414 C 2528 1414 2650 1421 2758 1434 L 3776 0 L 4314 0 L 3226 1536 z" transform="scale(0.015625)"/>
+    <path id="glyph-a" d="M 2298 3968 L 4070 0 L 4589 0 L 2541 4480 L 2054 4480 L 13 0 L 525 0 L 2298 3968 z" transform="scale(0.015625)"/>
+  </defs>
+  <g fill="#fff" transform="translate(0 148.40625) scale(2 -2)">
+    <use href="#glyph-e" xlink:href="#glyph-e"/>
+    <use href="#glyph-v" xlink:href="#glyph-v" x="66.899994"/>
+    <use href="#glyph-e" xlink:href="#glyph-e" x="136.899979"/>
+    <use href="#glyph-r" xlink:href="#glyph-r" x="203.799973"/>
+    <use href="#glyph-a" xlink:href="#glyph-a" x="276.199966"/>
   </g>
-  <g id="axes_1">
-   <g id="text_1">
-    <!-- EVERA -->
-    <g style="fill: #ffffff" transform="translate(0 148.40625) scale(2 -2)">
-     <defs>
-      <path id="MontserratAlt1-Regular-45" d="M 723 2067 
-L 3808 2067 
-L 3808 2483 
-L 723 2483 
-L 723 2067 
-z
-M 723 4102 
-L 3808 4102 
-L 3808 4531 
-L 723 4531 
-L 723 4102 
-z
-M 723 429 
-L 3808 429 
-L 3808 0 
-L 723 0 
-L 723 429 
-z
-" transform="scale(0.015625)"/>
-      <path id="MontserratAlt1-Regular-56" d="M 4467 4480 
-L 3968 4480 
-L 2253 614 
-L 550 4480 
-L 13 4480 
-L 1997 0 
-L 2483 0 
-L 4467 4480 
-z
-" transform="scale(0.015625)"/>
-      <path id="MontserratAlt1-Regular-52" d="M 3226 1536 
-C 3872 1747 4243 2240 4243 2944 
-C 4243 3904 3552 4480 2406 4480 
-L 723 4480 
-L 723 4051 
-L 2394 4051 
-C 3283 4051 3750 3648 3750 2944 
-C 3750 2240 3283 1837 2394 1837 
-L 723 1837 
-L 723 0 
-L 1216 0 
-L 1216 1414 
-L 2406 1414 
-C 2528 1414 2650 1421 2758 1434 
-L 3776 0 
-L 4314 0 
-L 3226 1536 
-z
-" transform="scale(0.015625)"/>
-      <path id="MontserratAlt1-Regular-41" d="M 2298 3968 
-L 4070 0 
-L 4589 0 
-L 2541 4480 
-L 2054 4480 
-L 13 0 
-L 525 0 
-L 2298 3968 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#MontserratAlt1-Regular-45"/>
-     <use xlink:href="#MontserratAlt1-Regular-56" x="66.899994"/>
-     <use xlink:href="#MontserratAlt1-Regular-45" x="136.899979"/>
-     <use xlink:href="#MontserratAlt1-Regular-52" x="203.799973"/>
-     <use xlink:href="#MontserratAlt1-Regular-41" x="276.199966"/>
-    </g>
-   </g>
-  </g>
- </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the Matplotlib-generated logo SVG with a clean, accessible version and add a reusable glow effect for all logo placements
- standardize body copy line-height to 1.4 with 1.6em spacing for paragraphs and lists while preserving component-specific overrides

## Testing
- Manually previewed `index.html` via `python -m http.server 8000`


------
https://chatgpt.com/codex/tasks/task_e_68e3fbcab2bc832f8aa9e196fdc19cbf