### PR TITLE
Ensure CTA spacing meets mobile requirements

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -510,9 +510,9 @@ h3{font-size:var(--h3); line-height:1.3; margin:0;}
   .timeline li::before{left:-20px;}
 }
 
-.cta{display:flex;flex-direction:column;align-items:stretch;flex-wrap:wrap;gap:var(--stack-gap);--stack-gap:var(--space-4);}
+.cta{display:flex;flex-direction:column;align-items:stretch;flex-wrap:wrap;gap:var(--stack-gap);--stack-gap:clamp(12px,4vw,16px);}
 .cta.stack > * + *{margin-top:0;}
-.cta.stack .btn + .btn{margin-top:var(--space-3);}
+.cta.stack .btn + .btn{margin-top:var(--stack-gap);}
 .cta-block{margin-top:0;background:rgba(12,30,51,.35);border:1px solid rgba(124,227,255,.18);border-radius:16px;padding:var(--space-6);box-shadow:0 18px 48px rgba(7,18,40,.35);display:flex;flex-direction:column;gap:var(--space-4);}
 .cta-block p{margin:0;color:var(--muted)}
 .cta-actions{display:flex;flex-wrap:wrap;gap:var(--space-3);margin:0;}
@@ -672,7 +672,7 @@ dialog .modal-actions .btn + .btn{margin-top:0;}
     padding-block:38px;
     padding-inline:20px;
   }
-  .cta{--stack-gap:var(--space-4);}
+  .cta{--stack-gap:clamp(12px,4vw,16px);}
   .cta-actions{flex-direction:column;align-items:stretch;gap:var(--space-3);}
 }
 


### PR DESCRIPTION
## Summary
- clamp the CTA stack gap between 12px and 16px on small screens to prevent oversized spacing
- align fallback button margins with the updated gap variable for consistent mobile spacing

## Testing
- playwright viewport checks at 320/360/380px portrait and 480/568/640px landscape widths

------
https://chatgpt.com/codex/tasks/task_e_68e3fbcf4be0832f85382bd1e5f555fa