### PR TITLE
Remove translucent panels from supporting sections

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -349,14 +349,13 @@ main, header, footer, section{position:relative;z-index:1}
 
 .section-surface{
   position:relative;
-  padding-block:var(--panel-pad-block);
-  padding-inline:var(--panel-pad-inline);
-  border-radius:var(--panel-radius);
-  border:1px solid var(--panel-border);
-  background:var(--panel-bg);
-  box-shadow:var(--panel-shadow);
-  backdrop-filter:blur(18px) saturate(160%);
-  -webkit-backdrop-filter:blur(18px) saturate(160%);
+  padding:0;
+  border-radius:0;
+  border:none;
+  background:none;
+  box-shadow:none;
+  backdrop-filter:none;
+  -webkit-backdrop-filter:none;
 }
 .section-surface > *{margin:0;}
 .section-surface.stack{--stack-gap:var(--space-5);}
@@ -364,12 +363,6 @@ main, header, footer, section{position:relative;z-index:1}
 .section-surface .lead{color:var(--muted);}
 .section-surface .section-cta{margin-top:var(--space-4); display:flex; flex-wrap:wrap; gap:var(--space-3);}
 .section-surface .section-cta .btn{margin-top:0;}
-@media (max-width:768px){
-  .section-surface{
-    padding-block:clamp(28px, 12vw, 56px);
-    padding-inline:clamp(20px, 8vw, 44px);
-  }
-}
 
 .hero{padding-top:calc(var(--space-section) + 32px)}
 .hero .overlay{


### PR DESCRIPTION
## Summary
- remove the frosted glass styling from `.section-surface` so only the hero keeps a panel overlay
- leave other section spacing logic intact for a lighter background that reveals the stars

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68e5156b0a5c832fba8d3afb5a0195d6