### PR TITLE
Team page: match home background layers and remove member icons/images

### DIFF
--- a/en/pages/team.html
+++ b/en/pages/team.html
@@ -56,8 +56,11 @@
   </noscript>
 
 <div class="read-progress" id="readProgress" aria-hidden="true"></div>
-<canvas id="nebula" aria-hidden="true"></canvas>
+<canvas id="nebula" data-parallax-speed="0.006" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
+<div class="parallax-layer parallax-layer--nebula" data-parallax-speed="0.008" aria-hidden="true"></div>
+<div class="parallax-layer parallax-layer--dust" data-parallax-speed="0.012" aria-hidden="true"></div>
+<div class="parallax-layer parallax-layer--sparks" data-parallax-speed="0.016" aria-hidden="true"></div>
 <header class="header header-nav">
   <div class="nav container">
     <a class="logo" href="/en/index.html" aria-label="EVERA">
@@ -156,81 +159,51 @@
         <p>These AI-agents are large language models trained on open knowledge sources and historical scientific heritage: published works, archives, academic research, contemporaries’ notes, and scholarly commentary. All referenced materials belong to the public domain or open-license resources.</p>
         <div class="profile-grid">
           <div class="profile-card">
-            <figure class="profile-media">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/d/d3/Albert_Einstein_Head.jpg" alt="Albert Einstein" loading="lazy">
-            </figure>
             <div class="role">Chief Vision &amp; Complexity Officer</div>
             <h3>Albert Einstein</h3>
             <p>Responsible for product vision, complex interconnections, and the architecture of meaning. Helps us see the system as a whole - a living space where people, data, and values come together.</p>
           </div>
           <div class="profile-card">
-            <figure class="profile-media">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/a/a4/Ada_Lovelace_portrait.jpg" alt="Ada Lovelace" loading="lazy">
-            </figure>
             <div class="role">Head of Algorithms &amp; Code Architecture</div>
             <h3>Ada Lovelace</h3>
             <p>The first computer programmer in human history.<br>Curator of algorithms, code structure, and engineering logic. Inspires the creation of clean, transparent, and elegant product architecture.</p>
           </div>
           <div class="profile-card">
-            <figure class="profile-media">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/a/a1/Alan_Turing_Aged_16.jpg" alt="Alan Turing" loading="lazy">
-            </figure>
             <div class="role">Director of AI Logic &amp; Verification</div>
             <h3>Alan Turing</h3>
             <p>Oversees reasoning quality, hypothesis verification, and logical resilience of AI. His domain is trust through mathematics and validation.</p>
           </div>
           <div class="profile-card">
-            <figure class="profile-media">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/d/d3/Albert_Einstein_Head.jpg" alt="Archimedes" loading="lazy">
-            </figure>
             <div class="role">Chief Systems Engineer</div>
             <h3>Archimedes</h3>
             <p>Responsible for the engineering implementation of ideas: scalability, reliability, systemic mechanics, and practical execution of complex solutions.</p>
           </div>
           <div class="profile-card">
-            <figure class="profile-media">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/a/a1/Alan_Turing_Aged_16.jpg" alt="Aristotle" loading="lazy">
-            </figure>
             <div class="role">Head of Ethics &amp; Methodology</div>
             <h3>Aristotle</h3>
             <p>Guardian of ethics, product philosophy, and the boundaries of what is acceptable. Builds the methodology where AI remains a tool - and the human remains the subject.</p>
           </div>
           <div class="profile-card">
-            <figure class="profile-media">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/a/a4/Ada_Lovelace_portrait.jpg" alt="Adam Smith" loading="lazy">
-            </figure>
             <div class="role">Chief Financial &amp; Monetization Strategist</div>
             <h3>Adam Smith</h3>
             <p>Designs the economic model, pricing, unit economics, and sustainable growth - ensuring that created value always exceeds the cost of ownership.</p>
           </div>
           <div class="profile-card">
-            <figure class="profile-media">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/d/d3/Albert_Einstein_Head.jpg" alt="Abraham Lincoln" loading="lazy">
-            </figure>
             <div class="role">Director of Communications &amp; Community</div>
             <h3>Abraham Lincoln</h3>
             <p>The voice of fairness, honesty, and dignity. Responsible for brand communication culture, strategic messaging, and value-based positioning.</p>
           </div>
           <div class="profile-card">
-            <figure class="profile-media">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/a/a1/Alan_Turing_Aged_16.jpg" alt="Leonardo da Vinci" loading="lazy">
-            </figure>
             <div class="role">Head of Product Design &amp; R&amp;D</div>
             <h3>Leonardo da Vinci</h3>
             <p>A synthesis of technology, design, and human experience. Ensures that UX is art - and product is harmony between form and meaning.</p>
           </div>
           <div class="profile-card">
-            <figure class="profile-media">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/a/a4/Ada_Lovelace_portrait.jpg" alt="Sofya Kovalevskaya" loading="lazy">
-            </figure>
             <div class="role">Chief Data &amp; Analytics Officer</div>
             <h3>Sofya Kovalevskaya</h3>
             <p>Metrics, user behavior, statistical validity, and forecasting - transforming data into insight.</p>
           </div>
           <div class="profile-card">
-            <figure class="profile-media">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/d/d3/Albert_Einstein_Head.jpg" alt="Sun Tzu" loading="lazy">
-            </figure>
             <div class="role">Strategy &amp; Risk Intelligence Lead</div>
             <h3>Sun Tzu</h3>
             <p>Positioning, strategic planning, risk analysis, and scenario thinking. Sees the whole field and prepares the project for a future where uncertainty is the norm.</p>

--- a/pages/team.html
+++ b/pages/team.html
@@ -48,8 +48,11 @@
   </noscript>
 
 <div class="read-progress" id="readProgress" aria-hidden="true"></div>
-<canvas id="nebula" aria-hidden="true"></canvas>
+<canvas id="nebula" data-parallax-speed="0.006" aria-hidden="true"></canvas>
 <canvas id="stars" aria-hidden="true"></canvas>
+<div class="parallax-layer parallax-layer--nebula" data-parallax-speed="0.008" aria-hidden="true"></div>
+<div class="parallax-layer parallax-layer--dust" data-parallax-speed="0.012" aria-hidden="true"></div>
+<div class="parallax-layer parallax-layer--sparks" data-parallax-speed="0.016" aria-hidden="true"></div>
 <header class="header header-nav">
   <div class="nav container">
     <a class="logo" href="/index.html" aria-label="EVERA">
@@ -147,120 +150,51 @@
         <p>Эти ИИ-агенты - большие языковые модели, обученные на открытых источниках знаний и исторического научного наследия: трудах, публикациях, архивах, записях современников и академических исследованиях. Вся используемая информация относится к общественному достоянию или открытым лицензиям.</p>
         <div class="profile-grid">
           <div class="profile-card">
-            <div class="profile-icon profile-icon--vision" aria-hidden="true">
-              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <circle cx="12" cy="12" r="8.5"></circle>
-                <path d="M10 10l6-2-2 6-6 2 2-6z"></path>
-              </svg>
-            </div>
             <div class="role">Chief Vision &amp; Complexity Officer</div>
             <h3>Альберт Эйнштейн</h3>
             <p>Отвечает за продукт-видение, сложные взаимосвязи и архитектуру смыслов. Помогает видеть систему целостно - как пространство, в котором соединяются люди, данные и ценности.</p>
           </div>
           <div class="profile-card">
-            <div class="profile-icon profile-icon--code" aria-hidden="true">
-              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M8 7 4 12l4 5"></path>
-                <path d="M16 7l4 5-4 5"></path>
-                <path d="M13 5 11 19"></path>
-              </svg>
-            </div>
             <div class="role">Head of Algorithms &amp; Code Architecture</div>
             <h3>Ада Лавлейс</h3>
             <p>Первый программист в истории человечества.<br>Куратор алгоритмов, структур кода и инженерной логики. Вдохновляет на создание чистой, прозрачной и элегантной архитектуры платформы.</p>
           </div>
           <div class="profile-card">
-            <div class="profile-icon profile-icon--logic" aria-hidden="true">
-              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M7 12l3 3 7-7"></path>
-                <path d="M6 6h12v12H6z"></path>
-              </svg>
-            </div>
             <div class="role">Director of AI Logic &amp; Verification</div>
             <h3>Алан Тьюринг</h3>
             <p>Следит за разумностью выводов, системной проверкой гипотез и устойчивостью логики ИИ. Его домен: доверие через математику и верификацию.</p>
           </div>
           <div class="profile-card">
-            <div class="profile-icon profile-icon--systems" aria-hidden="true">
-              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <circle cx="12" cy="12" r="3.5"></circle>
-                <path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.5 5.5l2.2 2.2M16.3 16.3l2.2 2.2M5.5 18.5l2.2-2.2M16.3 7.7l2.2-2.2"></path>
-              </svg>
-            </div>
             <div class="role">Chief Systems Engineer</div>
             <h3>Архимед</h3>
             <p>Отвечает за инженерное воплощение идей. Масштабирование, надёжность, системные механизмы и практическая реализация сложных решений.</p>
           </div>
           <div class="profile-card">
-            <div class="profile-icon profile-icon--ethics" aria-hidden="true">
-              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M12 4v14"></path>
-                <path d="M6 8h12"></path>
-                <path d="M5 8c0 3 2 5 4 5s4-2 4-5"></path>
-                <path d="M11 8c0 3 2 5 4 5s4-2 4-5"></path>
-              </svg>
-            </div>
             <div class="role">Head of Ethics &amp; Methodology</div>
             <h3>Аристотель</h3>
             <p>Куратор этики, философии продукта и границ допустимого. Формирует методологию, в рамках которой ИИ остаётся инструментом, а человек - субъектом.</p>
           </div>
           <div class="profile-card">
-            <div class="profile-icon profile-icon--finance" aria-hidden="true">
-              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <ellipse cx="12" cy="6.5" rx="6.5" ry="2.5"></ellipse>
-                <path d="M5.5 6.5v5c0 1.4 2.9 2.5 6.5 2.5s6.5-1.1 6.5-2.5v-5"></path>
-                <path d="M5.5 11.5v5c0 1.4 2.9 2.5 6.5 2.5s6.5-1.1 6.5-2.5v-5"></path>
-              </svg>
-            </div>
             <div class="role">Chief Financial &amp; Monetization Strategist</div>
             <h3>Адам Смит</h3>
             <p>Экономическая модель проекта, ценообразование, unit-экономика и устойчивость развития. Следит, чтобы создаваемая ценность всегда была выше стоимости владения.</p>
           </div>
           <div class="profile-card">
-            <div class="profile-icon profile-icon--voice" aria-hidden="true">
-              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M4 10v4"></path>
-                <path d="M8 8v8"></path>
-                <path d="M12 6v12"></path>
-                <path d="M16 8v8"></path>
-                <path d="M20 10v4"></path>
-              </svg>
-            </div>
             <div class="role">Director of Communications &amp; Community</div>
             <h3>Авраам Линкольн</h3>
             <p>Голос справедливости, честности и уважения. Отвечает за культуру общения с миром, стратегические коммуникации и ценностную опору бренда.</p>
           </div>
           <div class="profile-card">
-            <div class="profile-icon profile-icon--design" aria-hidden="true">
-              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M12 3l3.5 7 7 .6-5.5 4.6 1.8 7.2L12 18l-6.8 4.4 1.8-7.2L1.5 10.6 8.5 10z"></path>
-              </svg>
-            </div>
             <div class="role">Head of Product Design &amp; R&amp;D</div>
             <h3>Леонардо да Винчи</h3>
             <p>Синтез технологии, дизайна и человеческого опыта. Отвечает за UX как искусство и продукт как гармонию формы и смысла.</p>
           </div>
           <div class="profile-card">
-            <div class="profile-icon profile-icon--data" aria-hidden="true">
-              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M4 18V6"></path>
-                <path d="M10 18V9"></path>
-                <path d="M16 18v-6"></path>
-                <path d="M20 18V8"></path>
-                <path d="M4 13l4-4 4 3 6-6"></path>
-              </svg>
-            </div>
             <div class="role">Chief Data &amp; Analytics Officer</div>
             <h3>Софья Ковалевская</h3>
             <p>Метрики, поведение пользователей, статистическая валидность и прогнозирование. Превращает данные в понимание.</p>
           </div>
           <div class="profile-card">
-            <div class="profile-icon profile-icon--strategy" aria-hidden="true">
-              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M12 3l7 4v6c0 4.5-3 7.5-7 8-4-0.5-7-3.5-7-8V7l7-4z"></path>
-                <path d="M9 12l2 2 4-4"></path>
-              </svg>
-            </div>
             <div class="role">Strategy &amp; Risk Intelligence Lead</div>
             <h3>Сунь-цзы</h3>
             <p>Позиционирование, стратегия, анализ рисков и сценарное планирование. Видит поле целиком и готовит проект к будущему, где неопределённость - норма.</p>
@@ -274,11 +208,6 @@
         <h2>Основатель</h2>
         <div class="profile-grid">
           <div class="profile-card">
-            <div class="profile-icon profile-icon--founder" aria-hidden="true">
-              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M12 3l2.6 5.3 5.9.9-4.2 4.1 1 5.9-5.3-2.8-5.3 2.8 1-5.9-4.2-4.1 5.9-.9z"></path>
-              </svg>
-            </div>
             <div class="role">Founder &amp; Architect of EVERA</div>
             <h3>Максим Соломониди</h3>
           </div>


### PR DESCRIPTION
### Motivation
- Make the `team` pages visually consistent with the `home` layout by applying the same parallax/background layers and visual surface treatment.
- Remove all decorative icons and external images from team member cards because they produced a broken/misaligned appearance.

### Description
- Added parallax background elements (`<canvas id="nebula" data-parallax-speed=...>` and three `<div class="parallax-layer ...">`) to `pages/team.html` and `en/pages/team.html` to match the home page composition.
- Removed inline SVG icon blocks and `<figure class="profile-media"><img ...></figure>` image elements from every profile card and the founder card so cards render without icons/images.
- Changes are limited to the two files: `pages/team.html` and `en/pages/team.html`.

### Testing
- Launched a local static server with `python -m http.server 8000` and verified the updated page loads successfully, which completed without errors.
- Captured a full-page screenshot using a Playwright script that visited `http://127.0.0.1:8000/pages/team.html` and saved `artifacts/team-page.png`, which ran successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695024961abc832fbeba44e90d367a45)